### PR TITLE
Fix undefined reference to 'rialto_eme_protection_metadata_get_type'

### DIFF
--- a/source/RialtoGStreamerEMEProtectionMetadata.cpp
+++ b/source/RialtoGStreamerEMEProtectionMetadata.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "RialtoGStreamerEMEProtectionMetadata.h"
+#include <gst/gstconfig.h>
 
 static gboolean rialto_eme_protection_metadata_init(GstMeta *meta, gpointer params, GstBuffer *buffer)
 {
@@ -39,7 +40,7 @@ static gboolean rialto_eme_protection_metadata_free(GstMeta *meta, GstBuffer *bu
     return TRUE;
 }
 
-GType rialto_eme_protection_metadata_get_type()
+GST_EXPORT GType rialto_eme_protection_metadata_get_type()
 {
     static volatile GType g_type;
     static const gchar *api_tags[] = {"rialto", "protection", NULL};


### PR DESCRIPTION
Fixes the following linking error:
  rialto-gstreamer/git-r0/git/source/GStreamerEMEUtils.cpp:181:
  error: undefined reference to 'rialto_eme_protection_metadata_get_type'

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>

--
Summary: Fix undefined reference to 'rialto_eme_protection_metadata_get_type'
Type: fix
Owner: Damian Wrobel
Test Plan: None
Dependencies and Impacts: None