### PR TITLE
fix compiler warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ set( CMAKE_CXX_STANDARD 14 )
 set( CMAKE_CXX_STANDARD_REQUIRED ON )
 include( CheckCXXCompilerFlag )
 
+add_compile_options(-Wall -Werror)
+
 find_package( Rialto REQUIRED )
 find_package( ocdm REQUIRED )
 find_package( WPEFramework REQUIRED )

--- a/include/CdmBackend.h
+++ b/include/CdmBackend.h
@@ -30,7 +30,7 @@ public:
     CdmBackend() {}
     ~CdmBackend() {}
 
-    static const std::shared_ptr<firebolt::rialto::IMediaKeysCapabilities> &getMediaKeysCapabilities();
+    static const std::shared_ptr<firebolt::rialto::IMediaKeysCapabilities> getMediaKeysCapabilities();
     const std::unique_ptr<firebolt::rialto::IMediaKeys> &getMediaKeys() const;
     std::shared_ptr<MediaKeysClient> getMediaKeysClient();
 

--- a/source/CdmBackend.cpp
+++ b/source/CdmBackend.cpp
@@ -21,7 +21,7 @@
 
 std::shared_ptr<firebolt::rialto::IMediaKeysCapabilities> CdmBackend::m_mediaKeysCapabilities;
 
-const std::shared_ptr<firebolt::rialto::IMediaKeysCapabilities> &CdmBackend::getMediaKeysCapabilities()
+const std::shared_ptr<firebolt::rialto::IMediaKeysCapabilities> CdmBackend::getMediaKeysCapabilities()
 {
     if (!m_mediaKeysCapabilities)
     {

--- a/source/OpenCDMSession.cpp
+++ b/source/OpenCDMSession.cpp
@@ -65,10 +65,9 @@ const std::string kDefaultSessionId{"0"};
 OpenCDMSession::OpenCDMSession(std::weak_ptr<CdmBackend> cdm, const std::string &keySystem,
                                const LicenseType &sessionType, OpenCDMSessionCallbacks *callbacks, void *context,
                                const std::string &initDataType, const std::vector<uint8_t> &initData)
-    : mCDMBackend(cdm), mKeySystem(keySystem), mCallbacks(callbacks),
-      mRialtoSessionId(firebolt::rialto::kInvalidSessionId), mContext(context),
-      mSessionType(getRialtoSessionType(sessionType)), mInitDataType(getRialtoInitDataType(initDataType)),
-      mInitData(initData), mIsInitialized{false}
+    : mContext(context), mCDMBackend(cdm), mKeySystem(keySystem), mRialtoSessionId(firebolt::rialto::kInvalidSessionId),
+      mCallbacks(callbacks), mSessionType(getRialtoSessionType(sessionType)),
+      mInitDataType(getRialtoInitDataType(initDataType)), mInitData(initData), mIsInitialized{false}
 {
 }
 


### PR DESCRIPTION
Summary: fix compiler warning: 'returning reference to temporary'
Type: Bugfix
Test Plan: rialto-ocdm build
