### PR TITLE
Disable deprecated-declarations for gstreamer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,8 @@ include( CheckCXXCompilerFlag )
 
 add_compile_options(-Wall -Werror)
 
+# RIALTO-197: deprecated-declarations error in the latest stable2 for gstreamer.
+# Should be removed once the issue is fixed.
 add_compile_options(
   "-Wno-deprecated-declarations"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,10 @@ include( CheckCXXCompilerFlag )
 
 add_compile_options(-Wall -Werror)
 
+add_compile_options(
+  "-Wno-deprecated-declarations"
+)
+
 find_package( Rialto REQUIRED )
 find_package( ocdm REQUIRED )
 find_package( WPEFramework REQUIRED )


### PR DESCRIPTION
Summary: Disable deprecated-declarations when compiling rialto-ocdm to avoid compilation errors.
Type: BugFix
Test Plan: rialto-ocdm build
Jira: RIALTO-197