### PR TITLE
doxygen generation removed

### DIFF
--- a/.github/workflows/build_and_deploy_gh_pages.yml
+++ b/.github/workflows/build_and_deploy_gh_pages.yml
@@ -50,15 +50,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install dependencies 
-        run: |
-          sudo apt install doxygen graphviz
-
-      - name: Generate doxygen documentation
-        run: |
-          mkdir -p build/gh_pages
-          doxygen
-
       - name: Wait for coverage report generation
         uses: lewagon/wait-on-check-action@v1.2.0
         with:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # rialto-ocdm
 
+## Project webpage:
+https://rdkcentral.github.io/rialto-ocdm/
+
 ## Coding Guidelines:
 https://wiki.rdkcentral.com/display/ASP/Rialto+Coding+Guidelines
 


### PR DESCRIPTION
Summary: Doxygen generation removed from github pages yaml
Type: Fix
Test Plan: UT
Jira: RIALTO-272