### PR TITLE
Revert mock injection interface changes

### DIFF
--- a/tests/mocks/MediaKeysMock.h
+++ b/tests/mocks/MediaKeysMock.h
@@ -59,10 +59,7 @@ public:
 class MediaKeysFactoryMock : public IMediaKeysFactory
 {
 public:
-    MOCK_METHOD(std::unique_ptr<IMediaKeys>, createMediaKeys,
-                (const std::string &keySystem,
-                 std::weak_ptr<firebolt::rialto::client::IMediaKeysIpcFactory> mediaKeysIpcFactory),
-                (const, override));
+    MOCK_METHOD(std::unique_ptr<IMediaKeys>, createMediaKeys, (const std::string &keySystem), (const, override));
 };
 } // namespace firebolt::rialto
 

--- a/tests/ut/CdmBackendTests.cpp
+++ b/tests/ut/CdmBackendTests.cpp
@@ -47,8 +47,7 @@ public:
     void changeStateToRunning()
     {
         ASSERT_TRUE(m_mediaKeysFactoryMock);
-
-        EXPECT_CALL(*m_mediaKeysFactoryMock, createMediaKeys(kKeySystem, _))
+        EXPECT_CALL(*m_mediaKeysFactoryMock, createMediaKeys(kKeySystem))
             .WillOnce(Return(ByMove(std::move(m_mediaKeysMock))));
         m_sut.notifyApplicationState(firebolt::rialto::ApplicationState::RUNNING);
     }
@@ -83,7 +82,7 @@ TEST_F(CdmBackendTests, ShouldInitializeMediaKeysWhenSwitchedToRunningAgain)
 {
     changeStateToRunning();
     m_sut.notifyApplicationState(firebolt::rialto::ApplicationState::INACTIVE);
-    EXPECT_CALL(*m_mediaKeysFactoryMock, createMediaKeys(kKeySystem, _))
+    EXPECT_CALL(*m_mediaKeysFactoryMock, createMediaKeys(kKeySystem))
         .WillOnce(Return(ByMove(std::make_unique<StrictMock<firebolt::rialto::MediaKeysMock>>())));
     m_sut.notifyApplicationState(firebolt::rialto::ApplicationState::RUNNING);
 }
@@ -108,14 +107,14 @@ TEST_F(CdmBackendTests, ShouldFailToInitializeInRunningStateWhenFactoryIsNull)
 TEST_F(CdmBackendTests, ShouldFailToInitializeInRunningStateWhenMediaKeysIsNull)
 {
     ASSERT_TRUE(m_mediaKeysFactoryMock);
-    EXPECT_CALL(*m_mediaKeysFactoryMock, createMediaKeys(kKeySystem, _)).WillOnce(Return(nullptr));
+    EXPECT_CALL(*m_mediaKeysFactoryMock, createMediaKeys(kKeySystem)).WillOnce(Return(nullptr));
     EXPECT_FALSE(m_sut.initialize(firebolt::rialto::ApplicationState::RUNNING));
 }
 
 TEST_F(CdmBackendTests, ShouldInitializeInRunningState)
 {
     ASSERT_TRUE(m_mediaKeysFactoryMock);
-    EXPECT_CALL(*m_mediaKeysFactoryMock, createMediaKeys(kKeySystem, _))
+    EXPECT_CALL(*m_mediaKeysFactoryMock, createMediaKeys(kKeySystem))
         .WillOnce(Return(ByMove(std::make_unique<StrictMock<firebolt::rialto::MediaKeysMock>>())));
     EXPECT_TRUE(m_sut.initialize(firebolt::rialto::ApplicationState::RUNNING));
 }

--- a/tests/ut/OpenCdmSystemTests.cpp
+++ b/tests/ut/OpenCdmSystemTests.cpp
@@ -64,8 +64,7 @@ protected:
     {
         EXPECT_CALL(*m_controlFactoryMock, createControl()).WillOnce(Return(m_controlMock));
         EXPECT_CALL(*m_controlMock, registerClient(_, _)).WillOnce(DoAll(SetArgReferee<1>(kAppState), Return(true)));
-        EXPECT_CALL(*m_mediaKeysFactoryMock, createMediaKeys(kKeySystem, _))
-            .WillOnce(Return(ByMove(std::move(m_mediaKeys))));
+        EXPECT_CALL(*m_mediaKeysFactoryMock, createMediaKeys(kKeySystem)).WillOnce(Return(ByMove(std::move(m_mediaKeys))));
 
         auto messageDispatcher = std::make_shared<MessageDispatcher>();
         auto cdmBackend = std::make_shared<CdmBackend>(kKeySystem, messageDispatcher,


### PR DESCRIPTION
Summary: Removing the methods from public interface that allows for mock injection.
Type: Cleanup
Test Plan: Unittests.
Jira: NO-JIRA