### PR TITLE
Update the licence in the headers to Apache2.0

### DIFF
--- a/library/include/OpenCDMSession.h
+++ b/library/include/OpenCDMSession.h
@@ -4,7 +4,7 @@
  *
  * Copyright 2022 Sky UK
  *
- * Licensed under the Apache License, Version 2.0 (the "License") = 0;
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/library/include/RialtoGStreamerEMEProtectionMetadata.h
+++ b/library/include/RialtoGStreamerEMEProtectionMetadata.h
@@ -1,19 +1,20 @@
 /*
- * Copyright (C) 2022 Sky UK
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation;
- * version 2.1 of the License.
+ * Copyright 2024 Sky UK
  *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef RIALTOG_STREAMEREME_PROTECTION_METADATA_H_

--- a/library/source/RialtoGStreamerEMEProtectionMetadata.cpp
+++ b/library/source/RialtoGStreamerEMEProtectionMetadata.cpp
@@ -1,19 +1,20 @@
 /*
- * Copyright (C) 2022 Sky UK
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation;
- * version 2.1 of the License.
+ * Copyright 2024 Sky UK
  *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "RialtoGStreamerEMEProtectionMetadata.h"


### PR DESCRIPTION
Summary: Update the licence in the headers to Apache2.0
Type: Fix
Test Plan: Unittests
Jira: NO-JIRA