### PR TITLE
Fix native ocdm build. rialto 484

### DIFF
--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -2,7 +2,7 @@
 # If not stated otherwise in this file or this component's LICENSE file the
 # following copyright and licenses apply:
 #
-# Copyright 2023 Sky UK
+# Copyright 2024 Sky UK
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           repository: rdkcentral/rialto
           path: ./rialto
+          fetch-depth: 0
 
       - name: Install Dependencies
         run: |
@@ -59,6 +60,7 @@ jobs:
           BRANCH=${GITHUB_HEAD_REF##*/}
           cd rialto
           # This will fail if there's no corresponding branch in rialto
+          # ...but that's ok since we set continue-on-error
           git checkout $BRANCH
 
       - name: Native build Rialto

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -58,9 +58,10 @@ jobs:
         run: |
           BRANCH=${GITHUB_HEAD_REF##*/}
           cd rialto
+          # This will fail if there's no corresponding branch in rialto
           git checkout $BRANCH
 
-      - name: Build Rialto
+      - name: Native build Rialto
         run: |
           BASE_DIR=$(pwd)
           NATIVE_DIR=$BASE_DIR/native
@@ -69,7 +70,12 @@ jobs:
           cd rialto
           cmake . -B build  -DCMAKE_INSTALL_PREFIX=$NATIVE_DIR -DNATIVE_BUILD=ON -DRIALTO_BUILD_TYPE="Debug" &>> $BASE_DIR/output_file.txt
           make -C build install &>> $BASE_DIR/output_file.txt
-          cd ../rialto-ocdm
+
+      - name: Native build OCDM
+        run: |
+          BASE_DIR=$(pwd)
+          NATIVE_DIR=$BASE_DIR/native
+          cd rialto-ocdm
           echo "@@@ OCDM BUILD"  &>> $BASE_DIR/output_file.txt
           cmake . -B build -DCMAKE_INCLUDE_PATH="${NATIVE_DIR}/include"  -DCMAKE_LIBRARY_PATH="${NATIVE_DIR}/lib" -DNATIVE_BUILD=ON -DRIALTO_BUILD_TYPE="Debug" &>> $BASE_DIR/output_file.txt
           make -C build &>> $BASE_DIR/output_file.txt

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -42,12 +42,6 @@ jobs:
           repository: rdkcentral/rialto
           path: ./rialto
 
-      - name: Check out rialto-gstreamer
-        uses: actions/checkout@v3
-        with:
-          repository: rdkcentral/rialto-gstreamer
-          path: ./rialto-gstreamer
-
       - name: Install Dependencies
         run: |
           sudo apt-get update
@@ -63,33 +57,22 @@ jobs:
         run: |
           BASE_DIR=$(pwd)
           NATIVE_DIR=$BASE_DIR/native
-          echo $NATIVE_DIR &> $BASE_DIR/output_file.txt
+          echo "NATIVE_DIR=$NATIVE_DIR" &> $BASE_DIR/output_file.txt
           ls  &>> $BASE_DIR/output_file.txt
           cd rialto
+          git checkout ${GITHUB_REF##*/} # Try to switch to the same branch
           cmake . -B build  -DCMAKE_INSTALL_PREFIX=$NATIVE_DIR -DNATIVE_BUILD=ON -DRIALTO_BUILD_TYPE="Debug" &>> $BASE_DIR/output_file.txt
           if [ $? -ne 0 ]
           then
             exit 1
           fi
-          make -C build &>> $BASE_DIR/output_file.txt
-          if [ $? -ne 0 ]
-          then
-            exit 1
-          fi
-          cd ../rialto-gstreamer
-          echo "@@@ GSTREAMER"  &>> $BASE_DIR/output_file.txt
-          cmake . -B build -DCMAKE_INCLUDE_PATH="${NATIVE_DIR}/include" -DCMAKE_LIBRARY_PATH="${NATIVE_DIR}/lib" -DNATIVE_BUILD=ON -DRIALTO_BUILD_TYPE="Debug" --debug-find &>> $BASE_DIR/output_file.txt
-          if [ $? -ne 0 ]
-          then
-            exit 1
-          fi
-          make -C build  &>> $BASE_DIR/output_file.txt
+          make -C build install &>> $BASE_DIR/output_file.txt
           if [ $? -ne 0 ]
           then
             exit 1
           fi
           cd ../rialto-ocdm
-          echo "@@@ OCDM"  &>> $BASE_DIR/output_file.txt
+          echo "@@@ OCDM BUILD"  &>> $BASE_DIR/output_file.txt
           cmake . -B build -DCMAKE_INCLUDE_PATH="${NATIVE_DIR}/include"  -DCMAKE_LIBRARY_PATH="${NATIVE_DIR}/lib" -DNATIVE_BUILD=ON -DRIALTO_BUILD_TYPE="Debug" &>> $BASE_DIR/output_file.txt
           if [ $? -ne 0 ]
           then

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -63,8 +63,10 @@ jobs:
         run: |
           BASE_DIR=$(pwd)
           NATIVE_DIR=$BASE_DIR/native
+          echo $NATIVE_DIR &> $BASE_DIR/output_file.txt
+          ls  &>> $BASE_DIR/output_file.txt
           cd rialto
-          cmake . -B build  -DCMAKE_INSTALL_PREFIX=$NATIVE_DIR -DNATIVE_BUILD=ON -DRIALTO_BUILD_TYPE="Debug" &> $BASE_DIR/output_file.txt
+          cmake . -B build  -DCMAKE_INSTALL_PREFIX=$NATIVE_DIR -DNATIVE_BUILD=ON -DRIALTO_BUILD_TYPE="Debug" &>> $BASE_DIR/output_file.txt
           if [ $? -ne 0 ]
           then
             exit 1
@@ -75,23 +77,25 @@ jobs:
             exit 1
           fi
           cd ../rialto-gstreamer
-          cmake . -B build -DCMAKE_INCLUDE_PATH="${NATIVE_DIR}/include" -DCMAKE_LIBRARY_PATH="${NATIVE_DIR}/lib" -DNATIVE_BUILD=ON -DRIALTO_BUILD_TYPE="Debug" &>> $BASE_DIR/output_file.txt
+          echo "@@@ GSTREAMER"  &>> $BASE_DIR/output_file.txt
+          cmake . -B build -DCMAKE_INCLUDE_PATH="${NATIVE_DIR}/include" -DCMAKE_LIBRARY_PATH="${NATIVE_DIR}/lib" -DNATIVE_BUILD=ON -DRIALTO_BUILD_TYPE="Debug" --debug-find &>> $BASE_DIR/output_file.txt
           if [ $? -ne 0 ]
           then
             exit 1
           fi
-          make $makeOpts -C build  &>> $BASE_DIR/output_file.txt
+          make -C build  &>> $BASE_DIR/output_file.txt
           if [ $? -ne 0 ]
           then
             exit 1
           fi
           cd ../rialto-ocdm
+          echo "@@@ OCDM"  &>> $BASE_DIR/output_file.txt
           cmake . -B build -DCMAKE_INCLUDE_PATH="${NATIVE_DIR}/include"  -DCMAKE_LIBRARY_PATH="${NATIVE_DIR}/lib" -DNATIVE_BUILD=ON -DRIALTO_BUILD_TYPE="Debug" &>> $BASE_DIR/output_file.txt
           if [ $? -ne 0 ]
           then
             exit 1
           fi
-          make $makeOpts -C build &>> $BASE_DIR/output_file.txt
+          make -C build &>> $BASE_DIR/output_file.txt
           if [ $? -ne 0 ]
           then
             exit 1

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -1,4 +1,23 @@
-name: Native Rialto Build
+#
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2023 Sky UK
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Native Build
 
 on:
   pull_request:
@@ -14,7 +33,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-        path: rialto-ocdm
+        with:
+          path: rialto-ocdm
 
       - name: Check out rialto
         uses: actions/checkout@v3

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -53,6 +53,13 @@ jobs:
         run: |
           sudo apt-get install protobuf-compiler
 
+      - name: Switch branch
+        continue-on-error: true
+        run: |
+          BRANCH=${GITHUB_HEAD_REF##*/}
+          cd rialto
+          git checkout $BRANCH
+
       - name: Build Rialto
         run: |
           BASE_DIR=$(pwd)
@@ -60,29 +67,12 @@ jobs:
           echo "NATIVE_DIR=$NATIVE_DIR" &> $BASE_DIR/output_file.txt
           ls  &>> $BASE_DIR/output_file.txt
           cd rialto
-          git checkout ${GITHUB_REF##*/} # Try to switch to the same branch
           cmake . -B build  -DCMAKE_INSTALL_PREFIX=$NATIVE_DIR -DNATIVE_BUILD=ON -DRIALTO_BUILD_TYPE="Debug" &>> $BASE_DIR/output_file.txt
-          if [ $? -ne 0 ]
-          then
-            exit 1
-          fi
           make -C build install &>> $BASE_DIR/output_file.txt
-          if [ $? -ne 0 ]
-          then
-            exit 1
-          fi
           cd ../rialto-ocdm
           echo "@@@ OCDM BUILD"  &>> $BASE_DIR/output_file.txt
           cmake . -B build -DCMAKE_INCLUDE_PATH="${NATIVE_DIR}/include"  -DCMAKE_LIBRARY_PATH="${NATIVE_DIR}/lib" -DNATIVE_BUILD=ON -DRIALTO_BUILD_TYPE="Debug" &>> $BASE_DIR/output_file.txt
-          if [ $? -ne 0 ]
-          then
-            exit 1
-          fi
           make -C build &>> $BASE_DIR/output_file.txt
-          if [ $? -ne 0 ]
-          then
-            exit 1
-          fi
 
       - name: Report Build Status Success
         if: success()

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -1,0 +1,92 @@
+name: Native Rialto Build
+
+on:
+  pull_request:
+    branches: [ "master", "rdkcentral:master" ]
+  push:
+    branches: [ "master", "rdkcentral:master" ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        path: rialto-ocdm
+
+      - name: Check out rialto
+        uses: actions/checkout@v3
+        with:
+          repository: rdkcentral/rialto
+          path: ./rialto
+
+      - name: Check out rialto-gstreamer
+        uses: actions/checkout@v3
+        with:
+          repository: rdkcentral/rialto-gstreamer
+          path: ./rialto-gstreamer
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install build-essential
+          sudo apt-get install cmake
+          sudo apt-get install libunwind-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev libgstreamer1.0-dev
+
+      - name: Install protobuf
+        run: |
+          sudo apt-get install protobuf-compiler
+
+      - name: Build Rialto
+        run: |
+          BASE_DIR=$(pwd)
+          NATIVE_DIR=$BASE_DIR/native
+          cd rialto
+          cmake . -B build  -DCMAKE_INSTALL_PREFIX=$NATIVE_DIR -DNATIVE_BUILD=ON -DRIALTO_BUILD_TYPE="Debug" &> $BASE_DIR/output_file.txt
+          if [ $? -ne 0 ]
+          then
+            exit 1
+          fi
+          make -C build &>> $BASE_DIR/output_file.txt
+          if [ $? -ne 0 ]
+          then
+            exit 1
+          fi
+          cd ../rialto-gstreamer
+          cmake . -B build -DCMAKE_INCLUDE_PATH="${NATIVE_DIR}/include" -DCMAKE_LIBRARY_PATH="${NATIVE_DIR}/lib" -DNATIVE_BUILD=ON -DRIALTO_BUILD_TYPE="Debug" &>> $BASE_DIR/output_file.txt
+          if [ $? -ne 0 ]
+          then
+            exit 1
+          fi
+          make $makeOpts -C build  &>> $BASE_DIR/output_file.txt
+          if [ $? -ne 0 ]
+          then
+            exit 1
+          fi
+          cd ../rialto-ocdm
+          cmake . -B build -DCMAKE_INCLUDE_PATH="${NATIVE_DIR}/include"  -DCMAKE_LIBRARY_PATH="${NATIVE_DIR}/lib" -DNATIVE_BUILD=ON -DRIALTO_BUILD_TYPE="Debug" &>> $BASE_DIR/output_file.txt
+          if [ $? -ne 0 ]
+          then
+            exit 1
+          fi
+          make $makeOpts -C build &>> $BASE_DIR/output_file.txt
+          if [ $? -ne 0 ]
+          then
+            exit 1
+          fi
+
+      - name: Report Build Status Success
+        if: success()
+        run: |
+          echo "Build Succeeded!"
+          exit 0
+
+      - name: Upload Logs on Failure
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: Output Logs
+          path: |
+            output_file.txt

--- a/cmake/FindRialto.cmake
+++ b/cmake/FindRialto.cmake
@@ -2,7 +2,7 @@
 # If not stated otherwise in this file or this component's LICENSE file the
 # following copyright and licenses apply:
 #
-#  Copyright 2022 Sky UK
+#  Copyright 2024 Sky UK
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -17,6 +17,14 @@
 #  limitations under the License.
 #
 
+#############
+# NOTE
+# NOTE: This file is a copy of gstreamer/cmake/FindRialto.cmake
+# NOTE: Please keep these two files "in step"
+# NOTE: ...except for the different licence
+# NOTE
+#############
+
 # - Try to find the Rialto library.
 #
 # The following are set after configuration is done:
@@ -24,7 +32,7 @@
 #  RIALTO_INCLUDE_DIRS
 #  RIALTO_LIBRARY_DIRS
 #  RIALTO_LIBRARIES
-find_path( RIALTO_INCLUDE_DIR NAMES IMediaKeys.h PATH_SUFFIXES rialto)
+find_path( RIALTO_INCLUDE_DIR NAMES IMediaPipeline.h PATH_SUFFIXES rialto)
 find_library( RIALTO_LIBRARY NAMES libRialtoClient.so RialtoClient )
 
 #message( "RIALTO_INCLUDE_DIR include dir = ${RIALTO_INCLUDE_DIR}" )

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -17,10 +17,11 @@
 #  limitations under the License.
 #
 
-find_package( Rialto REQUIRED )
-find_package( ocdm REQUIRED )
+find_package(Rialto 1.0 REQUIRED)
 
-set(LIB_OCDM_RIALTO_SOURCES
+add_library(ocdmRialto
+
+        SHARED
         source/open_cdm.cpp
         source/open_cdm_adapter.cpp
         source/open_cdm_ext.cpp
@@ -34,8 +35,6 @@ set(LIB_OCDM_RIALTO_SOURCES
         source/MessageDispatcher.cpp
         source/RialtoGStreamerEMEProtectionMetadata.cpp)
 
-add_library(ocdmRialto SHARED ${LIB_OCDM_RIALTO_SOURCES} )
-
 set_target_properties(
         ocdmRialto
         PROPERTIES LINK_FLAGS "-Wl,--unresolved-symbols=report-all"
@@ -47,20 +46,25 @@ target_include_directories(
         ocdmRialto
 
         PUBLIC
-        $<INSTALL_INTERFACE:include/rialto>
+        include
+        ${CMAKE_INCLUDE_PATH}
+        ${CMAKE_INCLUDE_PATH}/rialto
+        ${GStreamerApp_INCLUDE_DIRS}
 
         PRIVATE
-        include
-        ${RIALTO_INCLUDE_DIR}
-        ${GStreamerApp_INCLUDE_DIRS}
         )
+
+include(CMakePrintHelpers)
+cmake_print_variables(Rialto::RialtoClient)
 
 target_link_libraries(
         ocdmRialto
 
+        PUBLIC
+        ${GStreamerApp_LIBRARIES}
+
         PRIVATE
         Rialto::RialtoClient
-        ${GStreamerApp_LIBRARIES}
         )
 
 include( GNUInstallDirs )

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -45,8 +45,6 @@ set_target_properties(
 target_include_directories(
         ocdmRialto
 
-        PUBLIC
-
         PRIVATE
         include
         ${CMAKE_INCLUDE_PATH}
@@ -56,8 +54,6 @@ target_include_directories(
 
 target_link_libraries(
         ocdmRialto
-
-        PUBLIC
 
         PRIVATE
         Rialto::RialtoClient

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -46,22 +46,22 @@ target_include_directories(
         ocdmRialto
 
         PUBLIC
+
+        PRIVATE
         include
         ${CMAKE_INCLUDE_PATH}
         ${CMAKE_INCLUDE_PATH}/rialto
         ${GStreamerApp_INCLUDE_DIRS}
-
-        PRIVATE
         )
 
 target_link_libraries(
         ocdmRialto
 
         PUBLIC
-        ${GStreamerApp_LIBRARIES}
 
         PRIVATE
         Rialto::RialtoClient
+        ${GStreamerApp_LIBRARIES}
         )
 
 include( GNUInstallDirs )

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -54,9 +54,6 @@ target_include_directories(
         PRIVATE
         )
 
-include(CMakePrintHelpers)
-cmake_print_variables(Rialto::RialtoClient)
-
 target_link_libraries(
         ocdmRialto
 


### PR DESCRIPTION
Summary: Fix the native build for OCDM. The cmake and make commands should work with the same arguments as supplied in the rialto-gstreamer native build
Type: Fix
Test Plan: Unit tests, component tests and native build
Jira: RIALTO-484