### PR TITLE
Print official release tag or git hash in rialto logs - rialto ocdm

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -108,6 +108,3 @@ endif()
 # Preprocesser Variable
 add_compile_definitions(SRCREV="${SRCREV}")
 add_compile_definitions(TAGS="${TAGS}")
-
-message("SRCREV: ${SRCREV}")
-message("TAGS: ${TAGS}")

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -84,7 +84,7 @@ execute_process(
     COMMAND git rev-parse HEAD
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} 
     RESULT_VARIABLE RESULT 
-    OUTPUT_VARIABLE COMMIT_ID 
+    OUTPUT_VARIABLE SRCREV 
     OUTPUT_STRIP_TRAILING_WHITESPACE 
 )
 
@@ -92,5 +92,22 @@ if(RESULT)
     message("Failed to get git commit ID: ${RESULT}")
 endif()
 
+# Retrieve release tag(s)
+execute_process(
+    COMMAND bash -c "git tag --list --contains ${SRCREV} | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}  
+    OUTPUT_VARIABLE TAGS
+    OUTPUT_STRIP_TRAILING_WHITESPACE 
+)
+string(REPLACE "\n" ", " TAGS "${TAGS}")
+
+if(NOT TAGS STREQUAL "")
+    set(TAGS ${TAGS})
+endif() 
+
 # Preprocesser Variable
-add_compile_definitions(COMMIT_ID="${COMMIT_ID}")
+add_compile_definitions(SRCREV="${SRCREV}")
+add_compile_definitions(TAGS="${TAGS}")
+
+message("SRCREV: ${SRCREV}")
+message("TAGS: ${TAGS}")

--- a/library/source/open_cdm.cpp
+++ b/library/source/open_cdm.cpp
@@ -48,11 +48,12 @@ OpenCDMSystem *opencdm_create_system(const char keySystem[])
     {
         if (std::strlen(kTags) > 0)
         {
-            kLog<< mil << "Release Tag(s): "<< kTags << "(Commit ID: "<< kSrcRev << ")";
+            kLog << mil << "Release Tag(s): " << kTags << " (Commit ID: " << kSrcRev << ")";
         }
         else
         {
-            kLog<< mil << "Release Tag(s): No Release Tags!"<< "(Commit ID: "<< kSrcRev << ")";
+            kLog << mil << "Release Tag(s): No Release Tags!"
+                 << " (Commit ID: " << kSrcRev << ")";
         }
     }
     else

--- a/library/source/open_cdm.cpp
+++ b/library/source/open_cdm.cpp
@@ -40,8 +40,29 @@ bool isPlayreadyKeysystem(const std::string &keySystem)
 OpenCDMSystem *opencdm_create_system(const char keySystem[])
 {
     kLog << debug << __func__;
-    const std::string kCommitId{COMMIT_ID};
-    kLog << info << "Commit ID: " << (kCommitId.empty() ? "Unknown" : kCommitId.c_str());
+    // const std::string kCommitId{COMMIT_ID};
+    // kLog << info << "Commit ID: " << (kCommitId.empty() ? "Unknown" : kCommitId.c_str());
+
+
+    const char kSrcRev[] = SRCREV;
+    const char kTags[] = TAGS;
+
+    if (std::strlen(kSrcRev) > 0)
+    {
+        if (std::strlen(kTags) > 0)
+        {
+            kLog<< mil << "Release Tag(s): "<< kTags << "(Commit ID: "<< kSrcRev << ")";
+        }
+        else
+        {
+            kLog<< mil << "Release Tag(s): No Release Tags!"<< "(Commit ID: "<< kSrcRev << ")";
+        }
+    }
+    else
+    {
+        kLog << warn << "Failed to get git commit ID!";
+    }
+
 
     OpenCDMSystem *result = nullptr;
     opencdm_create_system_extended(keySystem, &result);

--- a/library/source/open_cdm.cpp
+++ b/library/source/open_cdm.cpp
@@ -40,9 +40,6 @@ bool isPlayreadyKeysystem(const std::string &keySystem)
 OpenCDMSystem *opencdm_create_system(const char keySystem[])
 {
     kLog << debug << __func__;
-    // const std::string kCommitId{COMMIT_ID};
-    // kLog << info << "Commit ID: " << (kCommitId.empty() ? "Unknown" : kCommitId.c_str());
-
 
     const char kSrcRev[] = SRCREV;
     const char kTags[] = TAGS;
@@ -62,7 +59,6 @@ OpenCDMSystem *opencdm_create_system(const char keySystem[])
     {
         kLog << warn << "Failed to get git commit ID!";
     }
-
 
     OpenCDMSystem *result = nullptr;
     opencdm_create_system_extended(keySystem, &result);

--- a/tests/ut/CMakeLists.txt
+++ b/tests/ut/CMakeLists.txt
@@ -24,7 +24,7 @@ execute_process(
     COMMAND git rev-parse HEAD
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} 
     RESULT_VARIABLE RESULT 
-    OUTPUT_VARIABLE COMMIT_ID 
+    OUTPUT_VARIABLE SRCREV 
     OUTPUT_STRIP_TRAILING_WHITESPACE 
 )
 
@@ -32,8 +32,25 @@ if(RESULT)
     message("Failed to get git commit ID: ${RESULT}")
 endif()
 
+# Retrieve release tag(s)
+execute_process(
+    COMMAND bash -c "git tag --list --contains ${SRCREV} | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}  
+    OUTPUT_VARIABLE TAGS
+    OUTPUT_STRIP_TRAILING_WHITESPACE 
+)
+string(REPLACE "\n" ", " TAGS "${TAGS}")
+
+if(NOT TAGS STREQUAL "")
+    set(TAGS ${TAGS})
+endif() 
+
 # Preprocesser Variable
-add_compile_definitions(COMMIT_ID="${COMMIT_ID}")
+add_compile_definitions(SRCREV="${SRCREV}")
+add_compile_definitions(TAGS="${TAGS}")
+
+message("SRCREV!!!!!!! ${SRCREV}")
+message("TAGS!!!!!!!!! ${TAGS}")
 add_compile_definitions( RIALTO_ENABLE_DECRYPT_BUFFER )
 
 if ( COVERAGE_ENABLED )

--- a/tests/ut/CMakeLists.txt
+++ b/tests/ut/CMakeLists.txt
@@ -49,8 +49,6 @@ endif()
 add_compile_definitions(SRCREV="${SRCREV}")
 add_compile_definitions(TAGS="${TAGS}")
 
-message("SRCREV!!!!!!! ${SRCREV}")
-message("TAGS!!!!!!!!! ${TAGS}")
 add_compile_definitions( RIALTO_ENABLE_DECRYPT_BUFFER )
 
 if ( COVERAGE_ENABLED )


### PR DESCRIPTION
Summary: Printing release tag or git hash in rialto logs - rialto ocdm
Type: Fix
Test Plan: Unit tests and Full Stack
Jira: RIALTO-518