### PR TITLE
use rialto branch with the same name to download dependencies

### DIFF
--- a/tests/third-party/CMakeLists.txt
+++ b/tests/third-party/CMakeLists.txt
@@ -22,12 +22,31 @@ set( CMAKE_CXX_STANDARD 17 )
 set( CMAKE_CXX_STANDARD_REQUIRED ON )
 include( CheckCXXCompilerFlag )
 
-# Default to 'master' if branch is not specified
+# If branch is not specified, cmake will check, if branch with the same name exists in rialto repository
+# If not, 'master' branch will be used.
 if(BUILD_BRANCH)
     message("======= Branch specified, using '${BUILD_BRANCH}' branch =======")
 else()
-    set(BUILD_BRANCH "master")
-    message("======= No branch specified, using 'master' branch as default =======")
+    # Get current branch name
+    execute_process(
+        COMMAND git rev-parse --abbrev-ref HEAD
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE RIALTO_OCDM_BRANCH_NAME
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+	)
+    # Check if branch with the same name exists in rialto repository
+    execute_process(
+        COMMAND git ls-remote --exit-code --heads git@github.com:rdkcentral/rialto.git refs/heads/${RIALTO_OCDM_BRANCH_NAME}
+        RESULT_VARIABLE LS_REMOTE_RESULT
+    )
+
+    if("0" STREQUAL ${LS_REMOTE_RESULT})
+        message("======= No branch specified, using: '${RIALTO_OCDM_BRANCH_NAME}' branch as default =======")
+        set(BUILD_BRANCH ${RIALTO_OCDM_BRANCH_NAME})
+    else()
+        message("======= No branch specified, using 'master' branch as default =======")
+        set(BUILD_BRANCH "master")
+    endif()
 endif()
 
 # Function to download the relevant files, and to check if the file downloaded is empty 


### PR DESCRIPTION
Summary: Download external rialto headers from branch with the same name
Type: Feature
Test Plan: UnitTests
Jira: RIALTO-475