### PR TITLE
Register and unregister clients with proxy to fix data race, and tidy the surrounding code

### DIFF
--- a/library/source/OpenCDMSystemPrivate.cpp
+++ b/library/source/OpenCDMSystemPrivate.cpp
@@ -44,7 +44,7 @@ OpenCDMSystemPrivate::OpenCDMSystemPrivate(const std::string &system, const std:
         return;
     }
     firebolt::rialto::ApplicationState initialState{firebolt::rialto::ApplicationState::UNKNOWN};
-    m_control->registerClient(m_cdmBackend, initialState);
+    m_control->registerClientAndUnregisterOnDestruction(m_cdmBackend, initialState);
     m_cdmBackend->initialize(initialState);
 }
 

--- a/tests/mocks/ControlMock.h
+++ b/tests/mocks/ControlMock.h
@@ -35,7 +35,7 @@ public:
 class ControlMock : public IControl
 {
 public:
-    MOCK_METHOD(bool, registerClient, (std::weak_ptr<IControlClient> client, ApplicationState &appState), (override));
+    MOCK_METHOD(bool, registerClientAndUnregisterOnDestruction, (std::weak_ptr<IControlClient> client, ApplicationState &appState), (override));
 };
 } // namespace firebolt::rialto
 

--- a/tests/ut/OpenCdmSystemTests.cpp
+++ b/tests/ut/OpenCdmSystemTests.cpp
@@ -63,7 +63,7 @@ protected:
     void createValidSut()
     {
         EXPECT_CALL(*m_controlFactoryMock, createControl()).WillOnce(Return(m_controlMock));
-        EXPECT_CALL(*m_controlMock, registerClient(_, _)).WillOnce(DoAll(SetArgReferee<1>(kAppState), Return(true)));
+        EXPECT_CALL(*m_controlMock, registerClientAndUnregisterOnDestruction(_, _)).WillOnce(DoAll(SetArgReferee<1>(kAppState), Return(true)));
         EXPECT_CALL(*m_mediaKeysFactoryMock, createMediaKeys(kKeySystem)).WillOnce(Return(ByMove(std::move(m_mediaKeys))));
 
         auto messageDispatcher = std::make_shared<MessageDispatcher>();

--- a/tests/ut/OpenCdmTests.cpp
+++ b/tests/ut/OpenCdmTests.cpp
@@ -69,7 +69,7 @@ protected:
 TEST_F(OpenCdmTests, ShouldCreateAndDestroySystem)
 {
     EXPECT_CALL(*m_controlFactoryMock, createControl()).WillOnce(Return(m_controlMock));
-    EXPECT_CALL(*m_controlMock, registerClient(_, _)).WillOnce(Return(true));
+    EXPECT_CALL(*m_controlMock, registerClientAndUnregisterOnDestruction(_, _)).WillOnce(Return(true));
     auto *system{opencdm_create_system(kNetflixKeySystem.c_str())};
     EXPECT_NE(nullptr, system);
     EXPECT_EQ(ERROR_NONE, opencdm_destruct_system(system));


### PR DESCRIPTION
Summary: register and unregister clients (of control) via a proxy (this prevents a data race and updates c style pointers to c++). The call to registerClient in ControlService::addControl was deceiving since this didn't actually register any client... it just called setApplicationState therefore changed to call setApplicationState() direct (and then "controlServerInternal" doesn't need a "registerClient" method). Also the control method registerClient() is renamed to registerClientAndUnregisterOnDestruction() which is a more complete description of what it does
Type: Fix
Test Plan: UT/CT and test webaudio on XiOne US box
Jira: NO-JIRA