### PR TITLE
RDKEMW-19064:Querying Robustness level

### DIFF
--- a/library/include/MediaKeysCapabilitiesBackend.h
+++ b/library/include/MediaKeysCapabilitiesBackend.h
@@ -35,6 +35,7 @@ public:
     OpenCDMError supportsKeySystem(const std::string &keySystem);
     bool getSupportedKeySystemVersion(const std::string &keySystem, std::string &version);
     bool isServerCertificateSupported(const std::string &keySystem);
+    bool getSupportedRobustnessLevels(const std::string &keySystem, std::vector<std::string> &robustnessLevels);
 
 private:
     MediaKeysCapabilitiesBackend();

--- a/library/source/MediaKeysCapabilitiesBackend.cpp
+++ b/library/source/MediaKeysCapabilitiesBackend.cpp
@@ -69,6 +69,17 @@ bool MediaKeysCapabilitiesBackend::isServerCertificateSupported(const std::strin
     return result;
 }
 
+bool MediaKeysCapabilitiesBackend::getSupportedRobustnessLevels(const std::string &keySystem,
+                                                                std::vector<std::string> &robustnessLevels)
+{
+    bool result{false};
+    if (m_mediaKeysCapabilities)
+    {
+        result = m_mediaKeysCapabilities->getSupportedRobustnessLevels(keySystem, robustnessLevels);
+    }
+    return result;
+}
+
 MediaKeysCapabilitiesBackend::MediaKeysCapabilitiesBackend()
 {
     std::shared_ptr<firebolt::rialto::IMediaKeysCapabilitiesFactory> factory =

--- a/library/source/open_cdm.cpp
+++ b/library/source/open_cdm.cpp
@@ -83,8 +83,7 @@ OpenCDMError opencdm_destruct_system(struct OpenCDMSystem *system)
     return ERROR_NONE;
 }
 
-OpenCDMError opencdm_system_supported_robustness(struct OpenCDMSystem *system, char ***robustness,
-                                                 uint16_t *count)
+OpenCDMError opencdm_system_supported_robustness(struct OpenCDMSystem *system, char ***robustness, uint16_t *count)
 {
     kLog << debug << __func__;
     if (!system || !robustness || !count)

--- a/library/source/open_cdm.cpp
+++ b/library/source/open_cdm.cpp
@@ -82,6 +82,49 @@ OpenCDMError opencdm_destruct_system(struct OpenCDMSystem *system)
     return ERROR_NONE;
 }
 
+OpenCDMError opencdm_system_supported_robustness(struct OpenCDMSystem *system, char ***robustness,
+                                                  uint16_t *count)
+{
+    printf("%d %s KKP:Rialto\n",__LINE__,__PRETTY_FUNCTION__);fflush(stdout);
+    kLog << debug << __func__;
+    if (!system || !robustness || !count)
+    {
+        kLog << error << __func__ << ": system, robustness or count is NULL";
+        return ERROR_FAIL;
+    }
+
+    *robustness = nullptr;
+    *count = 0;
+
+    std::vector<std::string> levels;
+    if (!MediaKeysCapabilitiesBackend::instance().getSupportedRobustnessLevels(system->keySystem(), levels))
+    {
+        kLog << warn << __func__ << ": getSupportedRobustnessLevels failed or returned no levels";
+        return ERROR_FAIL;
+    }
+
+    if (levels.empty())
+    {
+        return ERROR_NONE;
+    }
+
+    char **results = static_cast<char **>(calloc(levels.size(), sizeof(char *)));
+    if (!results)
+    {
+        kLog << error << __func__ << ": failed to allocate robustness buffer";
+        return ERROR_FAIL;
+    }
+
+    for (size_t i = 0; i < levels.size(); ++i)
+    {
+        results[i] = strdup(levels[i].c_str());
+    }
+
+    *robustness = results;
+    *count = static_cast<uint16_t>(levels.size());
+    return ERROR_NONE;
+}
+
 OpenCDMError opencdm_is_type_supported(const char keySystem[], const char mimeType[])
 {
     kLog << debug << __func__;

--- a/library/source/open_cdm.cpp
+++ b/library/source/open_cdm.cpp
@@ -98,7 +98,7 @@ OpenCDMError opencdm_system_supported_robustness(struct OpenCDMSystem *system,
     std::vector<std::string> levels;
     if (!MediaKeysCapabilitiesBackend::instance().getSupportedRobustnessLevels(system->keySystem(), levels))
     {
-        kLog << warn << __func__ << ": getSupportedRobustnessLevels failed or returned no levels";
+        kLog << warn << __func__ << ": getSupportedRobustnessLevels failed";
         return ERROR_FAIL;
     }
 

--- a/library/source/open_cdm.cpp
+++ b/library/source/open_cdm.cpp
@@ -82,8 +82,8 @@ OpenCDMError opencdm_destruct_system(struct OpenCDMSystem *system)
     return ERROR_NONE;
 }
 
-OpenCDMError opencdm_system_supported_robustness(struct OpenCDMSystem *system, char ***robustness,
-                                                  uint16_t *count)
+OpenCDMError opencdm_system_supported_robustness(struct OpenCDMSystem *system,
+                                                 char ***robustness, uint16_t *count)
 {
     kLog << debug << __func__;
     if (!system || !robustness || !count)

--- a/library/source/open_cdm.cpp
+++ b/library/source/open_cdm.cpp
@@ -117,16 +117,16 @@ OpenCDMError opencdm_system_supported_robustness(struct OpenCDMSystem *system, c
     }
 
     char **results = static_cast<char **>(calloc(levels.size(), sizeof(char *)));
-    if (!results)
+    if (!results) // LCOV_EXCL_START
     {
         kLog << error << __func__ << ": failed to allocate robustness buffer";
         return ERROR_FAIL;
-    }
+    } // LCOV_EXCL_STOP
 
     for (size_t i = 0; i < levels.size(); ++i)
     {
         results[i] = strdup(levels[i].c_str());
-        if (!results[i])
+        if (!results[i]) // LCOV_EXCL_START
         {
             kLog << error << __func__ << ": failed to allocate robustness level string";
             for (size_t j = 0; j < i; ++j)
@@ -135,7 +135,7 @@ OpenCDMError opencdm_system_supported_robustness(struct OpenCDMSystem *system, c
             }
             free(results);
             return ERROR_FAIL;
-        }
+        } // LCOV_EXCL_STOP
     }
 
     *robustness = results;

--- a/library/source/open_cdm.cpp
+++ b/library/source/open_cdm.cpp
@@ -107,6 +107,11 @@ OpenCDMError opencdm_system_supported_robustness(struct OpenCDMSystem *system,
         return ERROR_NONE;
     }
 
+    if (levels.size() > 0xFFFF)
+    {
+        kLog << error << __func__ << ": robustness level count exceeds uint16_t range";
+        return ERROR_FAIL;
+    }
     char **results = static_cast<char **>(calloc(levels.size(), sizeof(char *)));
     if (!results)
     {

--- a/library/source/open_cdm.cpp
+++ b/library/source/open_cdm.cpp
@@ -112,12 +112,8 @@ OpenCDMError opencdm_system_supported_robustness(struct OpenCDMSystem *system, c
         kLog << error << __func__ << ": robustness level count exceeds uint16_t range";
         return ERROR_FAIL;
     }
+
     char **results = static_cast<char **>(calloc(levels.size(), sizeof(char *)));
-    if (!results)
-    {
-        kLog << error << __func__ << ": failed to allocate robustness buffer";
-        return ERROR_FAIL;
-    }
 
     for (size_t i = 0; i < levels.size(); ++i)
     {

--- a/library/source/open_cdm.cpp
+++ b/library/source/open_cdm.cpp
@@ -82,8 +82,8 @@ OpenCDMError opencdm_destruct_system(struct OpenCDMSystem *system)
     return ERROR_NONE;
 }
 
-OpenCDMError opencdm_system_supported_robustness(struct OpenCDMSystem *system,
-                                                 char ***robustness, uint16_t *count)
+OpenCDMError opencdm_system_supported_robustness(struct OpenCDMSystem *system, char ***robustness,
+                                                 uint16_t *count)
 {
     kLog << debug << __func__;
     if (!system || !robustness || !count)

--- a/library/source/open_cdm.cpp
+++ b/library/source/open_cdm.cpp
@@ -25,6 +25,7 @@
 #include "OpenCDMSession.h"
 #include "OpenCDMSystemPrivate.h"
 #include <cassert>
+#include <cstdlib>
 #include <cstring>
 
 namespace

--- a/library/source/open_cdm.cpp
+++ b/library/source/open_cdm.cpp
@@ -85,7 +85,6 @@ OpenCDMError opencdm_destruct_system(struct OpenCDMSystem *system)
 OpenCDMError opencdm_system_supported_robustness(struct OpenCDMSystem *system, char ***robustness,
                                                   uint16_t *count)
 {
-    printf("%d %s KKP:Rialto\n",__LINE__,__PRETTY_FUNCTION__);fflush(stdout);
     kLog << debug << __func__;
     if (!system || !robustness || !count)
     {

--- a/library/source/open_cdm.cpp
+++ b/library/source/open_cdm.cpp
@@ -27,6 +27,7 @@
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
 
 namespace
 {
@@ -83,6 +84,8 @@ OpenCDMError opencdm_destruct_system(struct OpenCDMSystem *system)
     return ERROR_NONE;
 }
 
+// C linkage is provided by the extern "C" block in open_cdm.h (declared in ThunderClientLibraries),
+// consistent with all other opencdm_* functions in this file.
 OpenCDMError opencdm_system_supported_robustness(struct OpenCDMSystem *system, char ***robustness, uint16_t *count)
 {
     kLog << debug << __func__;
@@ -107,17 +110,32 @@ OpenCDMError opencdm_system_supported_robustness(struct OpenCDMSystem *system, c
         return ERROR_NONE;
     }
 
-    if (levels.size() > 0xFFFF)
+    if (levels.size() > std::numeric_limits<uint16_t>::max())
     {
         kLog << error << __func__ << ": robustness level count exceeds uint16_t range";
         return ERROR_FAIL;
     }
 
     char **results = static_cast<char **>(calloc(levels.size(), sizeof(char *)));
+    if (!results)
+    {
+        kLog << error << __func__ << ": failed to allocate robustness buffer";
+        return ERROR_FAIL;
+    }
 
     for (size_t i = 0; i < levels.size(); ++i)
     {
         results[i] = strdup(levels[i].c_str());
+        if (!results[i])
+        {
+            kLog << error << __func__ << ": failed to allocate robustness level string";
+            for (size_t j = 0; j < i; ++j)
+            {
+                free(results[j]);
+            }
+            free(results);
+            return ERROR_FAIL;
+        }
     }
 
     *robustness = results;

--- a/library/source/open_cdm.cpp
+++ b/library/source/open_cdm.cpp
@@ -84,8 +84,6 @@ OpenCDMError opencdm_destruct_system(struct OpenCDMSystem *system)
     return ERROR_NONE;
 }
 
-// C linkage is provided by the extern "C" block in open_cdm.h (declared in ThunderClientLibraries),
-// consistent with all other opencdm_* functions in this file.
 OpenCDMError opencdm_system_supported_robustness(struct OpenCDMSystem *system, char ***robustness, uint16_t *count)
 {
     kLog << debug << __func__;

--- a/tests/mocks/MediaKeysCapabilitiesMock.h
+++ b/tests/mocks/MediaKeysCapabilitiesMock.h
@@ -41,6 +41,8 @@ public:
     MOCK_METHOD(bool, supportsKeySystem, (const std::string &keySystem), (override));
     MOCK_METHOD(bool, getSupportedKeySystemVersion, (const std::string &keySystem, std::string &version), (override));
     MOCK_METHOD(bool, isServerCertificateSupported, (const std::string &keySystem), (override));
+    MOCK_METHOD(bool, getSupportedRobustnessLevels,
+                (const std::string &keySystem, std::vector<std::string> &robustnessLevels), (override));
 };
 } // namespace firebolt::rialto
 

--- a/tests/ut/MediaKeysCapabilitiesBackendTests.cpp
+++ b/tests/ut/MediaKeysCapabilitiesBackendTests.cpp
@@ -25,7 +25,9 @@ using firebolt::rialto::MediaKeysCapabilitiesFactoryMock;
 using firebolt::rialto::MediaKeysCapabilitiesMock;
 using testing::_;
 using testing::AtLeast;
+using testing::DoAll;
 using testing::Return;
+using testing::SetArgReferee;
 using testing::StrictMock;
 
 namespace
@@ -81,4 +83,21 @@ TEST_F(MediaKeysCapabilitiesBackendTests, shouldGetSupportedServerCertificate)
 {
     EXPECT_CALL(*m_mediaKeysCapabilitiesMock, isServerCertificateSupported(kKeySystem)).WillOnce(Return(true));
     EXPECT_TRUE(MediaKeysCapabilitiesBackend::instance().isServerCertificateSupported(kKeySystem));
+}
+
+TEST_F(MediaKeysCapabilitiesBackendTests, shouldFailToGetSupportedRobustnessLevels)
+{
+    std::vector<std::string> levels{};
+    EXPECT_CALL(*m_mediaKeysCapabilitiesMock, getSupportedRobustnessLevels(kKeySystem, _)).WillOnce(Return(false));
+    EXPECT_FALSE(MediaKeysCapabilitiesBackend::instance().getSupportedRobustnessLevels(kKeySystem, levels));
+}
+
+TEST_F(MediaKeysCapabilitiesBackendTests, shouldGetSupportedRobustnessLevels)
+{
+    const std::vector<std::string> kLevels{"HW_SECURE_ALL", "SW_SECURE_CRYPTO"};
+    std::vector<std::string> levels{};
+    EXPECT_CALL(*m_mediaKeysCapabilitiesMock, getSupportedRobustnessLevels(kKeySystem, _))
+        .WillOnce(DoAll(SetArgReferee<1>(kLevels), Return(true)));
+    EXPECT_TRUE(MediaKeysCapabilitiesBackend::instance().getSupportedRobustnessLevels(kKeySystem, levels));
+    EXPECT_EQ(kLevels, levels);
 }

--- a/tests/ut/OpenCdmTests.cpp
+++ b/tests/ut/OpenCdmTests.cpp
@@ -490,7 +490,7 @@ TEST_F(OpenCdmTests, ShouldGetSupportedRobustnessWhenLevelsEmpty)
 
 TEST_F(OpenCdmTests, ShouldFailToGetSupportedRobustnessWhenTooManyLevels)
 {
-    const std::vector<std::string> kTooManyLevels(0x10000, "level");
+    std::vector<std::string> kTooManyLevels(0x10000);
     char **robustness{nullptr};
     uint16_t count{0};
     EXPECT_CALL(m_openCdmSystemMock, keySystem()).WillOnce(ReturnRef(kNetflixKeySystem));

--- a/tests/ut/OpenCdmTests.cpp
+++ b/tests/ut/OpenCdmTests.cpp
@@ -489,6 +489,17 @@ TEST_F(OpenCdmTests, ShouldGetSupportedRobustnessWhenLevelsEmpty)
     EXPECT_EQ(0, count);
 }
 
+TEST_F(OpenCdmTests, ShouldFailToGetSupportedRobustnessWhenTooManyLevels)
+{
+    const std::vector<std::string> kTooManyLevels(0x10000, "level");
+    char **robustness{nullptr};
+    uint16_t count{0};
+    EXPECT_CALL(m_openCdmSystemMock, keySystem()).WillOnce(ReturnRef(kNetflixKeySystem));
+    EXPECT_CALL(*m_mediaKeysCapabilitiesMock, getSupportedRobustnessLevels(kNetflixKeySystem, _))
+        .WillOnce(DoAll(SetArgReferee<1>(kTooManyLevels), Return(true)));
+    EXPECT_EQ(ERROR_FAIL, opencdm_system_supported_robustness(&m_openCdmSystemMock, &robustness, &count));
+}
+
 TEST_F(OpenCdmTests, ShouldGetSupportedRobustness)
 {
     const std::vector<std::string> kLevels{"HW_SECURE_ALL", "SW_SECURE_CRYPTO"};

--- a/tests/ut/OpenCdmTests.cpp
+++ b/tests/ut/OpenCdmTests.cpp
@@ -472,7 +472,8 @@ TEST_F(OpenCdmTests, ShouldFailToGetSupportedRobustnessWhenBackendFails)
     char **robustness{nullptr};
     uint16_t count{0};
     EXPECT_CALL(m_openCdmSystemMock, keySystem()).WillOnce(ReturnRef(kNetflixKeySystem));
-    EXPECT_CALL(*m_mediaKeysCapabilitiesMock, getSupportedRobustnessLevels(kNetflixKeySystem, _))
+    EXPECT_CALL(*m_mediaKeysCapabilitiesMock,
+                getSupportedRobustnessLevels(kNetflixKeySystem, _))    
         .WillOnce(Return(false));
     EXPECT_EQ(ERROR_FAIL, opencdm_system_supported_robustness(&m_openCdmSystemMock, &robustness, &count));
 }

--- a/tests/ut/OpenCdmTests.cpp
+++ b/tests/ut/OpenCdmTests.cpp
@@ -498,7 +498,7 @@ TEST_F(OpenCdmTests, ShouldFailToGetSupportedRobustnessWhenTooManyLevels)
     uint16_t count{0};
     EXPECT_CALL(m_openCdmSystemMock, keySystem()).WillOnce(ReturnRef(kNetflixKeySystem));
     EXPECT_CALL(*m_mediaKeysCapabilitiesMock,
-                 getSupportedRobustnessLevels(kNetflixKeySystem, _))    
+                 getSupportedRobustnessLevels(kNetflixKeySystem, _))
         .WillOnce(DoAll(SetArgReferee<1>(kTooManyLevels), Return(true)));
     EXPECT_EQ(ERROR_FAIL, opencdm_system_supported_robustness(&m_openCdmSystemMock, &robustness, &count));
 }

--- a/tests/ut/OpenCdmTests.cpp
+++ b/tests/ut/OpenCdmTests.cpp
@@ -472,9 +472,7 @@ TEST_F(OpenCdmTests, ShouldFailToGetSupportedRobustnessWhenBackendFails)
     char **robustness{nullptr};
     uint16_t count{0};
     EXPECT_CALL(m_openCdmSystemMock, keySystem()).WillOnce(ReturnRef(kNetflixKeySystem));
-    EXPECT_CALL(*m_mediaKeysCapabilitiesMock,
-                getSupportedRobustnessLevels(kNetflixKeySystem, _))
-        .WillOnce(Return(false));
+    EXPECT_CALL(*m_mediaKeysCapabilitiesMock, getSupportedRobustnessLevels(kNetflixKeySystem, _)).WillOnce(Return(false));
     EXPECT_EQ(ERROR_FAIL, opencdm_system_supported_robustness(&m_openCdmSystemMock, &robustness, &count));
 }
 
@@ -483,8 +481,7 @@ TEST_F(OpenCdmTests, ShouldGetSupportedRobustnessWhenLevelsEmpty)
     char **robustness{nullptr};
     uint16_t count{0};
     EXPECT_CALL(m_openCdmSystemMock, keySystem()).WillOnce(ReturnRef(kNetflixKeySystem));
-    EXPECT_CALL(*m_mediaKeysCapabilitiesMock,
-                getSupportedRobustnessLevels(kNetflixKeySystem, _))
+    EXPECT_CALL(*m_mediaKeysCapabilitiesMock, getSupportedRobustnessLevels(kNetflixKeySystem, _))
         .WillOnce(DoAll(SetArgReferee<1>(std::vector<std::string>{}), Return(true)));
     EXPECT_EQ(ERROR_NONE, opencdm_system_supported_robustness(&m_openCdmSystemMock, &robustness, &count));
     EXPECT_EQ(nullptr, robustness);
@@ -497,8 +494,7 @@ TEST_F(OpenCdmTests, ShouldFailToGetSupportedRobustnessWhenTooManyLevels)
     char **robustness{nullptr};
     uint16_t count{0};
     EXPECT_CALL(m_openCdmSystemMock, keySystem()).WillOnce(ReturnRef(kNetflixKeySystem));
-    EXPECT_CALL(*m_mediaKeysCapabilitiesMock,
-                getSupportedRobustnessLevels(kNetflixKeySystem, _))
+    EXPECT_CALL(*m_mediaKeysCapabilitiesMock, getSupportedRobustnessLevels(kNetflixKeySystem, _))
         .WillOnce(DoAll(SetArgReferee<1>(kTooManyLevels), Return(true)));
     EXPECT_EQ(ERROR_FAIL, opencdm_system_supported_robustness(&m_openCdmSystemMock, &robustness, &count));
 }
@@ -509,8 +505,7 @@ TEST_F(OpenCdmTests, ShouldGetSupportedRobustness)
     char **robustness{nullptr};
     uint16_t count{0};
     EXPECT_CALL(m_openCdmSystemMock, keySystem()).WillOnce(ReturnRef(kNetflixKeySystem));
-    EXPECT_CALL(*m_mediaKeysCapabilitiesMock,
-                getSupportedRobustnessLevels(kNetflixKeySystem, _))
+    EXPECT_CALL(*m_mediaKeysCapabilitiesMock, getSupportedRobustnessLevels(kNetflixKeySystem, _))
         .WillOnce(DoAll(SetArgReferee<1>(kLevels), Return(true)));
     EXPECT_EQ(ERROR_NONE, opencdm_system_supported_robustness(&m_openCdmSystemMock, &robustness, &count));
     ASSERT_NE(nullptr, robustness);

--- a/tests/ut/OpenCdmTests.cpp
+++ b/tests/ut/OpenCdmTests.cpp
@@ -472,7 +472,8 @@ TEST_F(OpenCdmTests, ShouldFailToGetSupportedRobustnessWhenBackendFails)
     char **robustness{nullptr};
     uint16_t count{0};
     EXPECT_CALL(m_openCdmSystemMock, keySystem()).WillOnce(ReturnRef(kNetflixKeySystem));
-    EXPECT_CALL(*m_mediaKeysCapabilitiesMock, getSupportedRobustnessLevels(kNetflixKeySystem, _))
+    EXPECT_CALL(*m_mediaKeysCapabilitiesMock,
+                 getSupportedRobustnessLevels(kNetflixKeySystem, _))
         .WillOnce(Return(false));
     EXPECT_EQ(ERROR_FAIL, opencdm_system_supported_robustness(&m_openCdmSystemMock, &robustness, &count));
 }
@@ -482,7 +483,8 @@ TEST_F(OpenCdmTests, ShouldGetSupportedRobustnessWhenLevelsEmpty)
     char **robustness{nullptr};
     uint16_t count{0};
     EXPECT_CALL(m_openCdmSystemMock, keySystem()).WillOnce(ReturnRef(kNetflixKeySystem));
-    EXPECT_CALL(*m_mediaKeysCapabilitiesMock, getSupportedRobustnessLevels(kNetflixKeySystem, _))
+    EXPECT_CALL(*m_mediaKeysCapabilitiesMock,
+                 getSupportedRobustnessLevels(kNetflixKeySystem, _))
         .WillOnce(DoAll(SetArgReferee<1>(std::vector<std::string>{}), Return(true)));
     EXPECT_EQ(ERROR_NONE, opencdm_system_supported_robustness(&m_openCdmSystemMock, &robustness, &count));
     EXPECT_EQ(nullptr, robustness);
@@ -495,7 +497,8 @@ TEST_F(OpenCdmTests, ShouldFailToGetSupportedRobustnessWhenTooManyLevels)
     char **robustness{nullptr};
     uint16_t count{0};
     EXPECT_CALL(m_openCdmSystemMock, keySystem()).WillOnce(ReturnRef(kNetflixKeySystem));
-    EXPECT_CALL(*m_mediaKeysCapabilitiesMock, getSupportedRobustnessLevels(kNetflixKeySystem, _))
+    EXPECT_CALL(*m_mediaKeysCapabilitiesMock,
+                 getSupportedRobustnessLevels(kNetflixKeySystem, _))    
         .WillOnce(DoAll(SetArgReferee<1>(kTooManyLevels), Return(true)));
     EXPECT_EQ(ERROR_FAIL, opencdm_system_supported_robustness(&m_openCdmSystemMock, &robustness, &count));
 }
@@ -506,7 +509,8 @@ TEST_F(OpenCdmTests, ShouldGetSupportedRobustness)
     char **robustness{nullptr};
     uint16_t count{0};
     EXPECT_CALL(m_openCdmSystemMock, keySystem()).WillOnce(ReturnRef(kNetflixKeySystem));
-    EXPECT_CALL(*m_mediaKeysCapabilitiesMock, getSupportedRobustnessLevels(kNetflixKeySystem, _))
+    EXPECT_CALL(*m_mediaKeysCapabilitiesMock,
+                 getSupportedRobustnessLevels(kNetflixKeySystem, _))
         .WillOnce(DoAll(SetArgReferee<1>(kLevels), Return(true)));
     EXPECT_EQ(ERROR_NONE, opencdm_system_supported_robustness(&m_openCdmSystemMock, &robustness, &count));
     ASSERT_NE(nullptr, robustness);

--- a/tests/ut/OpenCdmTests.cpp
+++ b/tests/ut/OpenCdmTests.cpp
@@ -23,6 +23,7 @@
 #include "OpenCDMSessionMock.h"
 #include "OpenCDMSystemMock.h"
 #include "opencdm/open_cdm.h"
+#include <cstdlib>
 #include <cstring>
 #include <gtest/gtest.h>
 
@@ -442,6 +443,10 @@ TEST_F(OpenCdmTests, ShouldGetMetricSystemData)
     EXPECT_CALL(m_openCdmSystemMock, getMetricSystemData(_)).WillOnce(DoAll(SetArgReferee<0>(buffer), Return(true)));
     EXPECT_EQ(ERROR_NONE, opencdm_get_metric_system_data(&m_openCdmSystemMock, &bufferLength, buffer.data()));
 }
+
+// function not declared in official interface
+// NOLINTNEXTLINE(build/function_format)
+OpenCDMError opencdm_system_supported_robustness(struct OpenCDMSystem *system, char ***robustness, uint16_t *count);
 
 TEST_F(OpenCdmTests, ShouldFailToGetSupportedRobustnessWhenSystemIsNull)
 {

--- a/tests/ut/OpenCdmTests.cpp
+++ b/tests/ut/OpenCdmTests.cpp
@@ -473,7 +473,7 @@ TEST_F(OpenCdmTests, ShouldFailToGetSupportedRobustnessWhenBackendFails)
     uint16_t count{0};
     EXPECT_CALL(m_openCdmSystemMock, keySystem()).WillOnce(ReturnRef(kNetflixKeySystem));
     EXPECT_CALL(*m_mediaKeysCapabilitiesMock,
-                 getSupportedRobustnessLevels(kNetflixKeySystem, _))
+                getSupportedRobustnessLevels(kNetflixKeySystem, _))
         .WillOnce(Return(false));
     EXPECT_EQ(ERROR_FAIL, opencdm_system_supported_robustness(&m_openCdmSystemMock, &robustness, &count));
 }
@@ -484,7 +484,7 @@ TEST_F(OpenCdmTests, ShouldGetSupportedRobustnessWhenLevelsEmpty)
     uint16_t count{0};
     EXPECT_CALL(m_openCdmSystemMock, keySystem()).WillOnce(ReturnRef(kNetflixKeySystem));
     EXPECT_CALL(*m_mediaKeysCapabilitiesMock,
-                 getSupportedRobustnessLevels(kNetflixKeySystem, _))
+                getSupportedRobustnessLevels(kNetflixKeySystem, _))
         .WillOnce(DoAll(SetArgReferee<1>(std::vector<std::string>{}), Return(true)));
     EXPECT_EQ(ERROR_NONE, opencdm_system_supported_robustness(&m_openCdmSystemMock, &robustness, &count));
     EXPECT_EQ(nullptr, robustness);
@@ -498,7 +498,7 @@ TEST_F(OpenCdmTests, ShouldFailToGetSupportedRobustnessWhenTooManyLevels)
     uint16_t count{0};
     EXPECT_CALL(m_openCdmSystemMock, keySystem()).WillOnce(ReturnRef(kNetflixKeySystem));
     EXPECT_CALL(*m_mediaKeysCapabilitiesMock,
-                 getSupportedRobustnessLevels(kNetflixKeySystem, _))
+                getSupportedRobustnessLevels(kNetflixKeySystem, _))
         .WillOnce(DoAll(SetArgReferee<1>(kTooManyLevels), Return(true)));
     EXPECT_EQ(ERROR_FAIL, opencdm_system_supported_robustness(&m_openCdmSystemMock, &robustness, &count));
 }
@@ -510,7 +510,7 @@ TEST_F(OpenCdmTests, ShouldGetSupportedRobustness)
     uint16_t count{0};
     EXPECT_CALL(m_openCdmSystemMock, keySystem()).WillOnce(ReturnRef(kNetflixKeySystem));
     EXPECT_CALL(*m_mediaKeysCapabilitiesMock,
-                 getSupportedRobustnessLevels(kNetflixKeySystem, _))
+                getSupportedRobustnessLevels(kNetflixKeySystem, _))
         .WillOnce(DoAll(SetArgReferee<1>(kLevels), Return(true)));
     EXPECT_EQ(ERROR_NONE, opencdm_system_supported_robustness(&m_openCdmSystemMock, &robustness, &count));
     ASSERT_NE(nullptr, robustness);

--- a/tests/ut/OpenCdmTests.cpp
+++ b/tests/ut/OpenCdmTests.cpp
@@ -472,8 +472,7 @@ TEST_F(OpenCdmTests, ShouldFailToGetSupportedRobustnessWhenBackendFails)
     char **robustness{nullptr};
     uint16_t count{0};
     EXPECT_CALL(m_openCdmSystemMock, keySystem()).WillOnce(ReturnRef(kNetflixKeySystem));
-    EXPECT_CALL(*m_mediaKeysCapabilitiesMock,
-                getSupportedRobustnessLevels(kNetflixKeySystem, _))    
+    EXPECT_CALL(*m_mediaKeysCapabilitiesMock, getSupportedRobustnessLevels(kNetflixKeySystem, _))
         .WillOnce(Return(false));
     EXPECT_EQ(ERROR_FAIL, opencdm_system_supported_robustness(&m_openCdmSystemMock, &robustness, &count));
 }

--- a/tests/ut/OpenCdmTests.cpp
+++ b/tests/ut/OpenCdmTests.cpp
@@ -442,3 +442,63 @@ TEST_F(OpenCdmTests, ShouldGetMetricSystemData)
     EXPECT_CALL(m_openCdmSystemMock, getMetricSystemData(_)).WillOnce(DoAll(SetArgReferee<0>(buffer), Return(true)));
     EXPECT_EQ(ERROR_NONE, opencdm_get_metric_system_data(&m_openCdmSystemMock, &bufferLength, buffer.data()));
 }
+
+TEST_F(OpenCdmTests, ShouldFailToGetSupportedRobustnessWhenSystemIsNull)
+{
+    char **robustness{nullptr};
+    uint16_t count{0};
+    EXPECT_EQ(ERROR_FAIL, opencdm_system_supported_robustness(nullptr, &robustness, &count));
+}
+
+TEST_F(OpenCdmTests, ShouldFailToGetSupportedRobustnessWhenRobustnessPtrIsNull)
+{
+    uint16_t count{0};
+    EXPECT_EQ(ERROR_FAIL, opencdm_system_supported_robustness(&m_openCdmSystemMock, nullptr, &count));
+}
+
+TEST_F(OpenCdmTests, ShouldFailToGetSupportedRobustnessWhenCountIsNull)
+{
+    char **robustness{nullptr};
+    EXPECT_EQ(ERROR_FAIL, opencdm_system_supported_robustness(&m_openCdmSystemMock, &robustness, nullptr));
+}
+
+TEST_F(OpenCdmTests, ShouldFailToGetSupportedRobustnessWhenBackendFails)
+{
+    char **robustness{nullptr};
+    uint16_t count{0};
+    EXPECT_CALL(m_openCdmSystemMock, keySystem()).WillOnce(ReturnRef(kNetflixKeySystem));
+    EXPECT_CALL(*m_mediaKeysCapabilitiesMock, getSupportedRobustnessLevels(kNetflixKeySystem, _))
+        .WillOnce(Return(false));
+    EXPECT_EQ(ERROR_FAIL, opencdm_system_supported_robustness(&m_openCdmSystemMock, &robustness, &count));
+}
+
+TEST_F(OpenCdmTests, ShouldGetSupportedRobustnessWhenLevelsEmpty)
+{
+    char **robustness{nullptr};
+    uint16_t count{0};
+    EXPECT_CALL(m_openCdmSystemMock, keySystem()).WillOnce(ReturnRef(kNetflixKeySystem));
+    EXPECT_CALL(*m_mediaKeysCapabilitiesMock, getSupportedRobustnessLevels(kNetflixKeySystem, _))
+        .WillOnce(DoAll(SetArgReferee<1>(std::vector<std::string>{}), Return(true)));
+    EXPECT_EQ(ERROR_NONE, opencdm_system_supported_robustness(&m_openCdmSystemMock, &robustness, &count));
+    EXPECT_EQ(nullptr, robustness);
+    EXPECT_EQ(0, count);
+}
+
+TEST_F(OpenCdmTests, ShouldGetSupportedRobustness)
+{
+    const std::vector<std::string> kLevels{"HW_SECURE_ALL", "SW_SECURE_CRYPTO"};
+    char **robustness{nullptr};
+    uint16_t count{0};
+    EXPECT_CALL(m_openCdmSystemMock, keySystem()).WillOnce(ReturnRef(kNetflixKeySystem));
+    EXPECT_CALL(*m_mediaKeysCapabilitiesMock, getSupportedRobustnessLevels(kNetflixKeySystem, _))
+        .WillOnce(DoAll(SetArgReferee<1>(kLevels), Return(true)));
+    EXPECT_EQ(ERROR_NONE, opencdm_system_supported_robustness(&m_openCdmSystemMock, &robustness, &count));
+    ASSERT_NE(nullptr, robustness);
+    EXPECT_EQ(static_cast<uint16_t>(kLevels.size()), count);
+    for (uint16_t i = 0; i < count; ++i)
+    {
+        EXPECT_STREQ(kLevels[i].c_str(), robustness[i]);
+        free(robustness[i]);
+    }
+    free(robustness);
+}


### PR DESCRIPTION
Summary: Implement a interfaces in webkit to query the robustness level from CDM
Type: Feature
Test Plan:Check the Widevine L1 DRM support on Glass/Stream with the test URL and regression testing of webapps
Jira: https://ccp.sys.comcast.net/browse/RDKEMW-19064