### PR TITLE
RDKEMW-22812: Add persistent DRM session support in Rialto

### DIFF
--- a/library/include/CdmBackend.h
+++ b/library/include/CdmBackend.h
@@ -47,9 +47,8 @@ public:
     bool createKeySession(firebolt::rialto::KeySessionType sessionType, int32_t &keySessionId) override;
     bool generateRequest(int32_t keySessionId, firebolt::rialto::InitDataType initDataType,
                          const std::vector<uint8_t> &initData,
-                         const std::vector<uint8_t> &cdmData = std::vector<uint8_t>{},
-                         const firebolt::rialto::LimitedDurationLicense &ldlState =
-                             firebolt::rialto::LimitedDurationLicense::NOT_SPECIFIED) override;
+                         const std::vector<uint8_t> &cdmData,
+                         const firebolt::rialto::LimitedDurationLicense &ldlState) override;
     bool loadSession(int32_t keySessionId) override;
     bool updateSession(int32_t keySessionId, const std::vector<uint8_t> &responseData) override;
     bool setDrmHeader(int32_t keySessionId, const std::vector<uint8_t> &requestData) override;

--- a/library/include/CdmBackend.h
+++ b/library/include/CdmBackend.h
@@ -46,8 +46,7 @@ public:
     bool containsKey(int32_t keySessionId, const std::vector<uint8_t> &keyId) override;
     bool createKeySession(firebolt::rialto::KeySessionType sessionType, int32_t &keySessionId) override;
     bool generateRequest(int32_t keySessionId, firebolt::rialto::InitDataType initDataType,
-                         const std::vector<uint8_t> &initData,
-                         const std::vector<uint8_t> &cdmData,
+                         const std::vector<uint8_t> &initData, const std::vector<uint8_t> &cdmData,
                          const firebolt::rialto::LimitedDurationLicense &ldlState) override;
     bool loadSession(int32_t keySessionId) override;
     bool updateSession(int32_t keySessionId, const std::vector<uint8_t> &responseData) override;

--- a/library/include/CdmBackend.h
+++ b/library/include/CdmBackend.h
@@ -47,7 +47,9 @@ public:
     bool createKeySession(firebolt::rialto::KeySessionType sessionType, int32_t &keySessionId) override;
     bool generateRequest(int32_t keySessionId, firebolt::rialto::InitDataType initDataType,
                          const std::vector<uint8_t> &initData,
-                         const firebolt::rialto::LimitedDurationLicense &ldlState) override;
+                         const std::vector<uint8_t> &cdmData = std::vector<uint8_t>{},
+                         const firebolt::rialto::LimitedDurationLicense &ldlState =
+                             firebolt::rialto::LimitedDurationLicense::NOT_SPECIFIED) override;
     bool loadSession(int32_t keySessionId) override;
     bool updateSession(int32_t keySessionId, const std::vector<uint8_t> &responseData) override;
     bool setDrmHeader(int32_t keySessionId, const std::vector<uint8_t> &requestData) override;

--- a/library/include/ICdmBackend.h
+++ b/library/include/ICdmBackend.h
@@ -39,7 +39,9 @@ public:
     virtual bool createKeySession(firebolt::rialto::KeySessionType sessionType, int32_t &keySessionId) = 0;
     virtual bool generateRequest(int32_t keySessionId, firebolt::rialto::InitDataType initDataType,
                                  const std::vector<uint8_t> &initData,
-                                 const firebolt::rialto::LimitedDurationLicense &ldlState) = 0;
+                                 const std::vector<uint8_t> &cdmData = std::vector<uint8_t>{},
+                                 const firebolt::rialto::LimitedDurationLicense &ldlState =
+                                     firebolt::rialto::LimitedDurationLicense::NOT_SPECIFIED) = 0;
     virtual bool loadSession(int32_t keySessionId) = 0;
     virtual bool updateSession(int32_t keySessionId, const std::vector<uint8_t> &responseData) = 0;
     virtual bool setDrmHeader(int32_t keySessionId, const std::vector<uint8_t> &requestData) = 0;

--- a/library/include/OpenCDMSessionPrivate.h
+++ b/library/include/OpenCDMSessionPrivate.h
@@ -94,6 +94,7 @@ private:
     std::vector<uint8_t> m_initData;
     bool m_isInitialized;
     std::vector<uint8_t> m_challengeData;
+    std::vector<uint8_t> m_lastCdmData;
     std::vector<uint8_t> m_playreadyKeyId;
     std::vector<uint8_t> m_queuedDrmHeader;
     std::map<std::vector<unsigned char>, firebolt::rialto::KeyStatus> m_keyStatuses;

--- a/library/source/CdmBackend.cpp
+++ b/library/source/CdmBackend.cpp
@@ -108,6 +108,7 @@ bool CdmBackend::createKeySession(firebolt::rialto::KeySessionType sessionType, 
 
 bool CdmBackend::generateRequest(int32_t keySessionId, firebolt::rialto::InitDataType initDataType,
                                  const std::vector<uint8_t> &initData,
+                                 const std::vector<uint8_t> &cdmData,
                                  const firebolt::rialto::LimitedDurationLicense &ldlState)
 {
     std::unique_lock<std::mutex> lock{m_mutex};
@@ -116,7 +117,7 @@ bool CdmBackend::generateRequest(int32_t keySessionId, firebolt::rialto::InitDat
         return false;
     }
     return firebolt::rialto::MediaKeyErrorStatus::OK ==
-           m_mediaKeys->generateRequest(keySessionId, initDataType, initData, ldlState);
+            m_mediaKeys->generateRequest(keySessionId, initDataType, initData, cdmData, ldlState);
 }
 
 bool CdmBackend::loadSession(int32_t keySessionId)

--- a/library/source/CdmBackend.cpp
+++ b/library/source/CdmBackend.cpp
@@ -107,8 +107,7 @@ bool CdmBackend::createKeySession(firebolt::rialto::KeySessionType sessionType, 
 }
 
 bool CdmBackend::generateRequest(int32_t keySessionId, firebolt::rialto::InitDataType initDataType,
-                                 const std::vector<uint8_t> &initData,
-                                 const std::vector<uint8_t> &cdmData,
+                                 const std::vector<uint8_t> &initData, const std::vector<uint8_t> &cdmData,
                                  const firebolt::rialto::LimitedDurationLicense &ldlState)
 {
     std::unique_lock<std::mutex> lock{m_mutex};
@@ -117,7 +116,7 @@ bool CdmBackend::generateRequest(int32_t keySessionId, firebolt::rialto::InitDat
         return false;
     }
     return firebolt::rialto::MediaKeyErrorStatus::OK ==
-            m_mediaKeys->generateRequest(keySessionId, initDataType, initData, cdmData, ldlState);
+           m_mediaKeys->generateRequest(keySessionId, initDataType, initData, cdmData, ldlState);
 }
 
 bool CdmBackend::loadSession(int32_t keySessionId)

--- a/library/source/OpenCDMSessionPrivate.cpp
+++ b/library/source/OpenCDMSessionPrivate.cpp
@@ -129,6 +129,10 @@ bool OpenCDMSessionPrivate::generateRequest(const std::string &initDataType, con
                                           cdmData,
                                           firebolt::rialto::LimitedDurationLicense::NOT_SPECIFIED))
         {
+            {
+                std::lock_guard<std::mutex> lock{m_mutex};
+                m_lastCdmData = cdmData;
+            }
             m_log << info << "Successfully generated the request for the session";
             initializeCdmKeySessionId();
             return true;
@@ -206,11 +210,13 @@ bool OpenCDMSessionPrivate::getChallengeDataSize(uint32_t &size, bool isLdl)
     }
 
     // Challenge will be reinitialized. Clear any previous data.
+    std::vector<uint8_t> cdmData;
     {
         std::unique_lock<std::mutex> lock{m_mutex};
         // Wait for previous challenge to be received before clearing it.
         m_challengeCv.wait_for(lock, std::chrono::milliseconds{250}, [this]() { return !m_challengeData.empty(); });
         m_challengeData.clear();
+        cdmData = m_lastCdmData;
     }
 
     if ((m_initDataType != firebolt::rialto::InitDataType::UNKNOWN) && (-1 != m_rialtoSessionId))
@@ -219,7 +225,7 @@ bool OpenCDMSessionPrivate::getChallengeDataSize(uint32_t &size, bool isLdl)
             isLdl ? firebolt::rialto::LimitedDurationLicense::ENABLED
                   : firebolt::rialto::LimitedDurationLicense::DISABLED;
         if (m_cdmBackend->generateRequest(m_rialtoSessionId, m_initDataType, m_initData,
-                                          std::vector<uint8_t>{}, kLdlState))
+                                          cdmData, kLdlState))
         {
             m_log << info << "Successfully generated the request for the session";
         }

--- a/library/source/OpenCDMSessionPrivate.cpp
+++ b/library/source/OpenCDMSessionPrivate.cpp
@@ -126,6 +126,7 @@ bool OpenCDMSessionPrivate::generateRequest(const std::string &initDataType, con
     if ((dataType != firebolt::rialto::InitDataType::UNKNOWN) && (-1 != m_rialtoSessionId))
     {
         if (m_cdmBackend->generateRequest(m_rialtoSessionId, dataType, initData,
+                                          cdmData,
                                           firebolt::rialto::LimitedDurationLicense::NOT_SPECIFIED))
         {
             m_log << info << "Successfully generated the request for the session";
@@ -217,7 +218,8 @@ bool OpenCDMSessionPrivate::getChallengeDataSize(uint32_t &size, bool isLdl)
         const firebolt::rialto::LimitedDurationLicense kLdlState =
             isLdl ? firebolt::rialto::LimitedDurationLicense::ENABLED
                   : firebolt::rialto::LimitedDurationLicense::DISABLED;
-        if (m_cdmBackend->generateRequest(m_rialtoSessionId, m_initDataType, m_initData, kLdlState))
+        if (m_cdmBackend->generateRequest(m_rialtoSessionId, m_initDataType, m_initData,
+                                          std::vector<uint8_t>{}, kLdlState))
         {
             m_log << info << "Successfully generated the request for the session";
         }

--- a/library/source/OpenCDMSessionPrivate.cpp
+++ b/library/source/OpenCDMSessionPrivate.cpp
@@ -125,8 +125,7 @@ bool OpenCDMSessionPrivate::generateRequest(const std::string &initDataType, con
 
     if ((dataType != firebolt::rialto::InitDataType::UNKNOWN) && (-1 != m_rialtoSessionId))
     {
-        if (m_cdmBackend->generateRequest(m_rialtoSessionId, dataType, initData,
-                                          cdmData,
+        if (m_cdmBackend->generateRequest(m_rialtoSessionId, dataType, initData, cdmData,
                                           firebolt::rialto::LimitedDurationLicense::NOT_SPECIFIED))
         {
             {
@@ -224,8 +223,7 @@ bool OpenCDMSessionPrivate::getChallengeDataSize(uint32_t &size, bool isLdl)
         const firebolt::rialto::LimitedDurationLicense kLdlState =
             isLdl ? firebolt::rialto::LimitedDurationLicense::ENABLED
                   : firebolt::rialto::LimitedDurationLicense::DISABLED;
-        if (m_cdmBackend->generateRequest(m_rialtoSessionId, m_initDataType, m_initData,
-                                          cdmData, kLdlState))
+        if (m_cdmBackend->generateRequest(m_rialtoSessionId, m_initDataType, m_initData, cdmData, kLdlState))
         {
             m_log << info << "Successfully generated the request for the session";
         }

--- a/library/source/open_cdm.cpp
+++ b/library/source/open_cdm.cpp
@@ -245,8 +245,12 @@ OpenCDMError opencdm_construct_session(struct OpenCDMSystem *system, const Licen
         ActiveSessions::instance().remove(newSession);
         return ERROR_FAIL;
     }
-    std::vector<uint8_t> cdmDataVec(reinterpret_cast<const uint8_t *>(CDMData),
-                                    reinterpret_cast<const uint8_t *>(CDMData) + CDMDataLength);
+    std::vector<uint8_t> cdmDataVec;
+    if (CDMData && CDMDataLength > 0)
+    {
+        cdmDataVec.assign(reinterpret_cast<const uint8_t *>(CDMData),
+                          reinterpret_cast<const uint8_t *>(CDMData) + CDMDataLength);
+    }
 
     if (!newSession->generateRequest(initializationDataType, initDataVec, cdmDataVec))
     {

--- a/library/source/open_cdm.cpp
+++ b/library/source/open_cdm.cpp
@@ -245,11 +245,8 @@ OpenCDMError opencdm_construct_session(struct OpenCDMSystem *system, const Licen
         ActiveSessions::instance().remove(newSession);
         return ERROR_FAIL;
     }
-    // Dummy CDM data for simulation/testing
-    std::vector<uint8_t> cdmDataVec = {9, 5, 4, 3};
-    kLog << error << "VRN cdmDataVec (dummy): " << static_cast<int>(cdmDataVec[0]) << " "
-         << static_cast<int>(cdmDataVec[1]) << " " << static_cast<int>(cdmDataVec[2]) << " "
-         << static_cast<int>(cdmDataVec[3]);
+    std::vector<uint8_t> cdmDataVec(reinterpret_cast<const uint8_t *>(CDMData),
+                                    reinterpret_cast<const uint8_t *>(CDMData) + CDMDataLength);
 
     if (!newSession->generateRequest(initializationDataType, initDataVec, cdmDataVec))
     {

--- a/library/source/open_cdm.cpp
+++ b/library/source/open_cdm.cpp
@@ -245,6 +245,7 @@ OpenCDMError opencdm_construct_session(struct OpenCDMSystem *system, const Licen
         ActiveSessions::instance().remove(newSession);
         return ERROR_FAIL;
     }
+
     std::vector<uint8_t> cdmDataVec;
     if (CDMData && CDMDataLength > 0)
     {

--- a/library/source/open_cdm.cpp
+++ b/library/source/open_cdm.cpp
@@ -245,8 +245,11 @@ OpenCDMError opencdm_construct_session(struct OpenCDMSystem *system, const Licen
         ActiveSessions::instance().remove(newSession);
         return ERROR_FAIL;
     }
-    std::vector<uint8_t> cdmDataVec(reinterpret_cast<const uint8_t *>(CDMData),
-                                    reinterpret_cast<const uint8_t *>(CDMData) + CDMDataLength);
+    // Dummy CDM data for simulation/testing
+    std::vector<uint8_t> cdmDataVec = {9, 5, 4, 3};
+    kLog << error << "VRN cdmDataVec (dummy): " << static_cast<int>(cdmDataVec[0]) << " "
+         << static_cast<int>(cdmDataVec[1]) << " " << static_cast<int>(cdmDataVec[2]) << " "
+         << static_cast<int>(cdmDataVec[3]);
 
     if (!newSession->generateRequest(initializationDataType, initDataVec, cdmDataVec))
     {

--- a/library/source/open_cdm.cpp
+++ b/library/source/open_cdm.cpp
@@ -248,7 +248,7 @@ OpenCDMError opencdm_construct_session(struct OpenCDMSystem *system, const Licen
     std::vector<uint8_t> cdmDataVec(reinterpret_cast<const uint8_t *>(CDMData),
                                     reinterpret_cast<const uint8_t *>(CDMData) + CDMDataLength);
 
-    if (!newSession->generateRequest(initializationDataType, initDataVec, cdmDataVec /*not used yet*/))
+    if (!newSession->generateRequest(initializationDataType, initDataVec, cdmDataVec))
     {
         kLog << error << "Failed to generate request";
 

--- a/tests/mocks/CdmBackendMock.h
+++ b/tests/mocks/CdmBackendMock.h
@@ -34,9 +34,8 @@ public:
     MOCK_METHOD(bool, createKeySession, (firebolt::rialto::KeySessionType sessionType, int32_t &keySessionId),
                 (override));
     MOCK_METHOD(bool, generateRequest,
-                (int32_t keySessionId, firebolt::rialto::InitDataType initDataType,
-                 const std::vector<uint8_t> &initData, const std::vector<uint8_t> &cdmData,
-                 const firebolt::rialto::LimitedDurationLicense &ldlState),
+                (int32_t keySessionId, firebolt::rialto::InitDataType initDataType, const std::vector<uint8_t> &initData,
+                 const std::vector<uint8_t> &cdmData, const firebolt::rialto::LimitedDurationLicense &ldlState),
                 (override));
     MOCK_METHOD(bool, loadSession, (int32_t keySessionId), (override));
     MOCK_METHOD(bool, updateSession, (int32_t keySessionId, const std::vector<uint8_t> &responseData), (override));

--- a/tests/mocks/CdmBackendMock.h
+++ b/tests/mocks/CdmBackendMock.h
@@ -35,7 +35,8 @@ public:
                 (override));
     MOCK_METHOD(bool, generateRequest,
                 (int32_t keySessionId, firebolt::rialto::InitDataType initDataType,
-                 const std::vector<uint8_t> &initData, const firebolt::rialto::LimitedDurationLicense &ldlState),
+                 const std::vector<uint8_t> &initData, const std::vector<uint8_t> &cdmData,
+                 const firebolt::rialto::LimitedDurationLicense &ldlState),
                 (override));
     MOCK_METHOD(bool, loadSession, (int32_t keySessionId), (override));
     MOCK_METHOD(bool, updateSession, (int32_t keySessionId, const std::vector<uint8_t> &responseData), (override));

--- a/tests/mocks/MediaKeysMock.h
+++ b/tests/mocks/MediaKeysMock.h
@@ -37,7 +37,7 @@ public:
                 (KeySessionType sessionType, std::weak_ptr<IMediaKeysClient> client, int32_t &keySessionId), (override));
     MOCK_METHOD(MediaKeyErrorStatus, generateRequest,
                 (int32_t keySessionId, InitDataType initDataType, const std::vector<uint8_t> &initData,
-                 const LimitedDurationLicense &ldlState),
+                 const std::vector<uint8_t> &cdmData, const LimitedDurationLicense &ldlState),
                 (override));
     MOCK_METHOD(MediaKeyErrorStatus, loadSession, (int32_t keySessionId), (override));
     MOCK_METHOD(MediaKeyErrorStatus, updateSession, (int32_t keySessionId, const std::vector<uint8_t> &responseData),

--- a/tests/ut/CdmBackendTests.cpp
+++ b/tests/ut/CdmBackendTests.cpp
@@ -185,23 +185,23 @@ TEST_F(CdmBackendTests, ShouldCreateKeySession)
 
 TEST_F(CdmBackendTests, ShouldFailToGenerateRequestWhenMediaKeysIsNotPresent)
 {
-    EXPECT_FALSE(m_sut.generateRequest(kKeySessionId, kInitDataType, kBytes, kLdlState));
+    EXPECT_FALSE(m_sut.generateRequest(kKeySessionId, kInitDataType, kBytes, kBytes, kLdlState));
 }
 
 TEST_F(CdmBackendTests, ShouldFailToGenerateRequest)
 {
-    EXPECT_CALL(*m_mediaKeysMock, generateRequest(kKeySessionId, kInitDataType, kBytes, kLdlState))
+    EXPECT_CALL(*m_mediaKeysMock, generateRequest(kKeySessionId, kInitDataType, kBytes, kBytes, kLdlState))
         .WillOnce(Return(firebolt::rialto::MediaKeyErrorStatus::FAIL));
     changeStateToRunning();
-    EXPECT_FALSE(m_sut.generateRequest(kKeySessionId, kInitDataType, kBytes, kLdlState));
+    EXPECT_FALSE(m_sut.generateRequest(kKeySessionId, kInitDataType, kBytes, kBytes, kLdlState));
 }
 
 TEST_F(CdmBackendTests, ShouldGenerateRequest)
 {
-    EXPECT_CALL(*m_mediaKeysMock, generateRequest(kKeySessionId, kInitDataType, kBytes, kLdlState))
+    EXPECT_CALL(*m_mediaKeysMock, generateRequest(kKeySessionId, kInitDataType, kBytes, kBytes, kLdlState))
         .WillOnce(Return(firebolt::rialto::MediaKeyErrorStatus::OK));
     changeStateToRunning();
-    EXPECT_TRUE(m_sut.generateRequest(kKeySessionId, kInitDataType, kBytes, kLdlState));
+    EXPECT_TRUE(m_sut.generateRequest(kKeySessionId, kInitDataType, kBytes, kBytes, kLdlState));
 }
 
 TEST_F(CdmBackendTests, ShouldFailToLoadSessionWhenMediaKeysIsNotPresent)

--- a/tests/ut/OpenCdmSessionTests.cpp
+++ b/tests/ut/OpenCdmSessionTests.cpp
@@ -247,7 +247,7 @@ TEST_F(OpenCdmSessionTests, ShouldNotGenerateRequestWhenOperationFails)
 {
     createSut();
     initializeSut();
-    EXPECT_CALL(*m_cdmBackendMock, generateRequest(kKeySessionId, kRialtoInitDataType, kBytes1, kLdlState))
+    EXPECT_CALL(*m_cdmBackendMock, generateRequest(kKeySessionId, kRialtoInitDataType, kBytes1, kBytes2, kLdlState))
         .WillOnce(Return(false));
     EXPECT_CALL(*m_cdmBackendMock, getLastDrmError(kKeySessionId, _)).WillOnce(Return(false));
     EXPECT_FALSE(m_sut->generateRequest(kInitDataType, kBytes1, kBytes2));
@@ -258,7 +258,7 @@ TEST_F(OpenCdmSessionTests, ShouldGenerateRequest)
 {
     createSut();
     initializeSut();
-    EXPECT_CALL(*m_cdmBackendMock, generateRequest(kKeySessionId, kRialtoInitDataType, kBytes1, kLdlState))
+    EXPECT_CALL(*m_cdmBackendMock, generateRequest(kKeySessionId, kRialtoInitDataType, kBytes1, kBytes2, kLdlState))
         .WillOnce(Return(true));
     EXPECT_CALL(*m_cdmBackendMock, getCdmKeySessionId(kKeySessionId, _)).WillOnce(Return(false));
     EXPECT_TRUE(m_sut->generateRequest(kInitDataType, kBytes1, kBytes2));
@@ -270,13 +270,13 @@ TEST_F(OpenCdmSessionTests, ShouldGenerateRequestForAllInitDataTypes)
     createSut();
     initializeSut();
     EXPECT_CALL(*m_cdmBackendMock,
-                generateRequest(kKeySessionId, firebolt::rialto::InitDataType::CENC, kBytes1, kLdlState))
+                generateRequest(kKeySessionId, firebolt::rialto::InitDataType::CENC, kBytes1, kBytes2, kLdlState))
         .WillOnce(Return(true));
     EXPECT_CALL(*m_cdmBackendMock, getCdmKeySessionId(kKeySessionId, _)).WillOnce(Return(false));
     EXPECT_TRUE(m_sut->generateRequest("cenc", kBytes1, kBytes2));
 
     EXPECT_CALL(*m_cdmBackendMock,
-                generateRequest(kKeySessionId, firebolt::rialto::InitDataType::WEBM, kBytes1, kLdlState))
+                generateRequest(kKeySessionId, firebolt::rialto::InitDataType::WEBM, kBytes1, kBytes2, kLdlState))
         .WillOnce(Return(true));
     EXPECT_CALL(*m_cdmBackendMock, getCdmKeySessionId(kKeySessionId, _)).WillOnce(Return(false));
     EXPECT_TRUE(m_sut->generateRequest("webm", kBytes1, kBytes2));
@@ -719,7 +719,7 @@ TEST_F(OpenCdmSessionTests, ShouldReturnDefaultSessionIdWhenGetCdmKeySessionIdFa
 {
     createSut();
     initializeSut();
-    EXPECT_CALL(*m_cdmBackendMock, generateRequest(kKeySessionId, kRialtoInitDataType, kBytes1, kLdlState))
+    EXPECT_CALL(*m_cdmBackendMock, generateRequest(kKeySessionId, kRialtoInitDataType, kBytes1, kBytes2, kLdlState))
         .WillOnce(Return(true));
     EXPECT_CALL(*m_cdmBackendMock, getCdmKeySessionId(kKeySessionId, _)).WillOnce(Return(false));
     EXPECT_TRUE(m_sut->generateRequest(kInitDataType, kBytes1, kBytes2));
@@ -732,7 +732,7 @@ TEST_F(OpenCdmSessionTests, ShouldReturnSessionId)
     const std::string cdmSessionId{"id"};
     createSut();
     initializeSut();
-    EXPECT_CALL(*m_cdmBackendMock, generateRequest(kKeySessionId, kRialtoInitDataType, kBytes1, kLdlState))
+    EXPECT_CALL(*m_cdmBackendMock, generateRequest(kKeySessionId, kRialtoInitDataType, kBytes1, kBytes2, kLdlState))
         .WillOnce(Return(true));
     EXPECT_CALL(*m_cdmBackendMock, getCdmKeySessionId(kKeySessionId, _))
         .WillOnce(DoAll(SetArgReferee<1>(cdmSessionId), Return(true)));

--- a/tests/ut/OpenCdmSessionTests.cpp
+++ b/tests/ut/OpenCdmSessionTests.cpp
@@ -358,10 +358,10 @@ TEST_F(OpenCdmSessionTests, ShouldGetChallengeData)
     uint32_t challengeDataSize{0};
     createSut();
     initializeSut();
-    EXPECT_CALL(*m_cdmBackendMock, generateRequest(kKeySessionId, kRialtoInitDataType, kBytes1,
+    EXPECT_CALL(*m_cdmBackendMock, generateRequest(kKeySessionId, kRialtoInitDataType, kBytes1, std::vector<uint8_t>{},
                                                    firebolt::rialto::LimitedDurationLicense::DISABLED))
         .WillOnce(Invoke(
-            [&](int32_t, firebolt::rialto::InitDataType, const std::vector<uint8_t> &,
+            [&](int32_t, firebolt::rialto::InitDataType, const std::vector<uint8_t> &, const std::vector<uint8_t> &,
                 firebolt::rialto::LimitedDurationLicense)
             {
                 requestLicense();
@@ -394,7 +394,7 @@ TEST_F(OpenCdmSessionTests, ShouldFailToGetChallengeDataSizeWhenOperationFails)
     uint32_t challengeDataSize{0};
     createSut();
     initializeSut();
-    EXPECT_CALL(*m_cdmBackendMock, generateRequest(kKeySessionId, kRialtoInitDataType, kBytes1,
+    EXPECT_CALL(*m_cdmBackendMock, generateRequest(kKeySessionId, kRialtoInitDataType, kBytes1, std::vector<uint8_t>{},
                                                    firebolt::rialto::LimitedDurationLicense::DISABLED))
         .WillOnce(Return(false));
     EXPECT_CALL(*m_cdmBackendMock, getLastDrmError(kKeySessionId, _)).WillOnce(Return(false));
@@ -407,15 +407,42 @@ TEST_F(OpenCdmSessionTests, ShouldGetChallengeDataSize)
     uint32_t challengeDataSize{0};
     createSut();
     initializeSut();
-    EXPECT_CALL(*m_cdmBackendMock, generateRequest(kKeySessionId, kRialtoInitDataType, kBytes1,
+    EXPECT_CALL(*m_cdmBackendMock, generateRequest(kKeySessionId, kRialtoInitDataType, kBytes1, std::vector<uint8_t>{},
                                                    firebolt::rialto::LimitedDurationLicense::DISABLED))
         .WillOnce(Invoke(
-            [&](int32_t, firebolt::rialto::InitDataType, const std::vector<uint8_t> &,
+            [&](int32_t, firebolt::rialto::InitDataType, const std::vector<uint8_t> &, const std::vector<uint8_t> &,
                 firebolt::rialto::LimitedDurationLicense)
             {
                 requestLicense();
                 return true;
             }));
+    EXPECT_TRUE(m_sut->getChallengeDataSize(challengeDataSize, kIsLdl));
+    EXPECT_EQ(challengeDataSize, kBytes1.size());
+    teardownSut();
+}
+
+TEST_F(OpenCdmSessionTests, ShouldUseStoredCdmDataWhenGettingChallengeDataSize)
+{
+    uint32_t challengeDataSize{0};
+    createSut();
+    initializeSut();
+
+    EXPECT_CALL(*m_cdmBackendMock, generateRequest(kKeySessionId, kRialtoInitDataType, kBytes1, kBytes2, kLdlState))
+        .WillOnce(Return(true));
+    EXPECT_CALL(*m_cdmBackendMock, getCdmKeySessionId(kKeySessionId, _)).WillOnce(Return(false));
+    EXPECT_TRUE(m_sut->generateRequest(kInitDataType, kBytes1, kBytes2));
+
+    EXPECT_CALL(*m_cdmBackendMock,
+                generateRequest(kKeySessionId, kRialtoInitDataType, kBytes1, kBytes2,
+                                firebolt::rialto::LimitedDurationLicense::DISABLED))
+        .WillOnce(Invoke(
+            [&](int32_t, firebolt::rialto::InitDataType, const std::vector<uint8_t> &, const std::vector<uint8_t> &,
+                firebolt::rialto::LimitedDurationLicense)
+            {
+                requestLicense();
+                return true;
+            }));
+
     EXPECT_TRUE(m_sut->getChallengeDataSize(challengeDataSize, kIsLdl));
     EXPECT_EQ(challengeDataSize, kBytes1.size());
     teardownSut();

--- a/tests/ut/OpenCdmSessionTests.cpp
+++ b/tests/ut/OpenCdmSessionTests.cpp
@@ -432,9 +432,8 @@ TEST_F(OpenCdmSessionTests, ShouldUseStoredCdmDataWhenGettingChallengeDataSize)
     EXPECT_CALL(*m_cdmBackendMock, getCdmKeySessionId(kKeySessionId, _)).WillOnce(Return(false));
     EXPECT_TRUE(m_sut->generateRequest(kInitDataType, kBytes1, kBytes2));
 
-    EXPECT_CALL(*m_cdmBackendMock,
-                generateRequest(kKeySessionId, kRialtoInitDataType, kBytes1, kBytes2,
-                                firebolt::rialto::LimitedDurationLicense::DISABLED))
+    EXPECT_CALL(*m_cdmBackendMock, generateRequest(kKeySessionId, kRialtoInitDataType, kBytes1, kBytes2,
+                                                   firebolt::rialto::LimitedDurationLicense::DISABLED))
         .WillOnce(Invoke(
             [&](int32_t, firebolt::rialto::InitDataType, const std::vector<uint8_t> &, const std::vector<uint8_t> &,
                 firebolt::rialto::LimitedDurationLicense)


### PR DESCRIPTION
RDKEMW-22812: Add persistent DRM session support in Rialto

Reason for change: Implement persistent-license session support in Rialto-OCDM for Widevine and PlayReady DRM. This enables applications to create, store, restore, and reuse persistent DRM sessions across application restarts in compliance with EME persistent-license
Test Procedure: Verify persistent-license session creation for Widevine & PlayReady DRM